### PR TITLE
Keylock checking and crossdungeon enemizer fix

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -2,7 +2,7 @@ import copy
 from enum import Enum, unique, Flag
 import logging
 import json
-from collections import OrderedDict, deque
+from collections import OrderedDict, deque, defaultdict
 
 from EntranceShuffle import door_addresses
 from _vendor.collections_extended import bag
@@ -69,6 +69,7 @@ class World(object):
         self.dungeon_layouts = {}
         self.inaccessible_regions = {}
         self.key_logic = {}
+        self.key_layout = defaultdict(dict)
 
         for player in range(1, players + 1):
             def set_player_attr(attr, val):

--- a/DoorShuffle.py
+++ b/DoorShuffle.py
@@ -951,6 +951,7 @@ def find_valid_combination(builder, start_regions, world, player, drop_keys=True
     reassign_key_doors(builder, proposal, world, player)
     log_key_logic(builder.name, key_layout.key_logic)
     world.key_logic[player][builder.name] = key_layout.key_logic
+    world.key_layout[player][builder.name] = key_layout
     return True
 
 

--- a/KeyDoorShuffle.py
+++ b/KeyDoorShuffle.py
@@ -252,15 +252,10 @@ def unique_child_door(child, key_counter):
 
 
 def find_best_counter(door, odd_counter, key_counter, key_layout, world, player, skip_bk, empty_flag):  # try to waste as many keys as possible?
-    ignored_doors = {door, door.dest} if door is not None else {}
-    finished = False
-    opened_doors = dict(key_counter.open_doors)
     bk_opened = key_counter.big_key_opened
-    # new_counter = key_counter
-    last_counter = key_counter
 
     def score(counter):
-        return (counter.used_keys - len(counter.key_only_locations), counter.used_keys)
+        return (counter.used_keys - len(counter.key_only_locations), counter.used_keys, counter.big_key_opened)
 
     best_counter = max((i for i in key_layout.key_counters.values() if door not in i.open_doors and
                     set(i.open_doors.keys()).issuperset(set(key_counter.open_doors.keys())) and

--- a/KeyDoorShuffle.py
+++ b/KeyDoorShuffle.py
@@ -1238,7 +1238,7 @@ def val_rule(rule, skn, allow=False, loc=None, askn=None, setCheck=None):
 # Soft lock stuff
 def validate_key_placement(key_layout, world, player):
     if world.retro[player] or world.accessibility[player] == 'none':
-        return True # Can't keylock in retro.  Expected if beatable only.
+        return True  # Can't keylock in retro.  Expected if beatable only.
     max_counter = find_max_counter(key_layout)
     keys_outside = 0
     big_key_outside = False
@@ -1254,6 +1254,8 @@ def validate_key_placement(key_layout, world, player):
         if len(counter.child_doors) == 0:
             continue
         big_found = any(i.item == dungeon.big_key for i in counter.free_locations if "- Big Chest" not in i.name) or big_key_outside
+        if counter.big_key_opened and not big_found:
+            continue  # Can't get to this state
         found_locations = set(i for i in counter.free_locations if big_found or "- Big Chest" not in i.name)
         found_keys = sum(1 for i in found_locations if i.item is not None and i.item.name == smallkey_name and i.item.player == player) + \
                      len(counter.key_only_locations) + keys_outside

--- a/KeyDoorShuffle.py
+++ b/KeyDoorShuffle.py
@@ -147,8 +147,9 @@ def analyze_dungeon(key_layout, world, player):
             if not child.bigKey and child not in doors_completed:
                 best_counter = find_best_counter(child, odd_counter, key_counter, key_layout, world, player, False, empty_flag)
                 rule = create_rule(best_counter, key_counter, key_layout, world, player)
-                if not rule.is_valid:
-                    logging.getLogger('').warning('Key logic for door %s requires too many chests.  Seed may be beatable anyway.', child.name)
+                # todo: seems to be caused by best_counter not opening the big key door when that's logically required.  Re-evaluate usage of this
+                # if not rule.is_valid:
+                #     logging.getLogger('').warning('Key logic for door %s requires too many chests.  Seed may be beatable anyway.', child.name)
                 if smallest_rule is None or rule.small_key_num < smallest_rule:
                     smallest_rule = rule.small_key_num
                 check_for_self_lock_key(rule, child, best_counter, key_layout, world, player)
@@ -1232,3 +1233,41 @@ def val_rule(rule, skn, allow=False, loc=None, askn=None, setCheck=None):
     assert len(setCheck) == len(rule.alternate_big_key_loc)
     for loc in rule.alternate_big_key_loc:
         assert loc.name in setCheck
+
+
+# Soft lock stuff
+def validate_key_placement(key_layout, world, player):
+    if world.retro[player] or world.accessibility[player] == 'none':
+        return True # Can't keylock in retro.  Expected if beatable only.
+    max_counter = find_max_counter(key_layout)
+    keys_outside = 0
+    big_key_outside = False
+    dungeon = world.get_dungeon(key_layout.sector.name, player)
+    smallkey_name = 'Small Key (%s)' % (key_layout.sector.name if key_layout.sector.name != 'Hyrule Castle' else 'Escape')
+    if world.keyshuffle[player]:
+        keys_outside = key_layout.max_chests - sum(1 for i in max_counter.free_locations if i.item is not None and i.item.name == smallkey_name and i.item.player == player)
+    if world.bigkeyshuffle[player]:
+        max_counter = find_max_counter(key_layout)
+        big_key_outside = dungeon.big_key not in (l.item for l in max_counter.free_locations)
+
+    for counter in key_layout.key_counters.values():
+        if len(counter.child_doors) == 0:
+            continue
+        big_found = any(i.item == dungeon.big_key for i in counter.free_locations if "- Big Chest" not in i.name) or big_key_outside
+        found_locations = set(i for i in counter.free_locations if big_found or "- Big Chest" not in i.name)
+        found_keys = sum(1 for i in found_locations if i.item is not None and i.item.name == smallkey_name and i.item.player == player) + \
+                     len(counter.key_only_locations) + keys_outside
+        can_progress = (not counter.big_key_opened and big_found and any(d.bigKey for d in counter.child_doors)) or \
+                       found_keys > counter.used_keys and any(not d.bigKey for d in counter.child_doors)
+        if not can_progress:
+            missing_locations = set(max_counter.free_locations.keys()).difference(found_locations)
+            missing_items = [l for l in missing_locations if l.item is None or (l.item.name != smallkey_name and l.item != dungeon.big_key) or "- Boss" in l.name]
+            #missing_key_only = set(max_counter.key_only_locations.keys()).difference(counter.key_only_locations.keys()) # do freestanding keys matter for locations?
+            if len(missing_items) > 0: #world.accessibility[player]=='locations' and (len(missing_locations)>0 or len(missing_key_only) > 0):
+                logging.getLogger('').error("Keylock - can't open locations: ")
+                for i in missing_locations:
+                    logging.getLogger('').error(i)
+                return False
+
+    return True
+

--- a/KeyDoorShuffle.py
+++ b/KeyDoorShuffle.py
@@ -470,7 +470,7 @@ def bk_restricted_rules(rule, door, odd_counter, empty_flag, key_counter, key_la
         return
     best_counter = find_best_counter(door, odd_counter, key_counter, key_layout, world, player, True, empty_flag)
     bk_rule = create_rule(best_counter, key_counter, key_layout, world, player)
-    if bk_rule.small_key_num >= rule.small_key_num:
+    if bk_rule.small_key_num >= rule.small_key_num and bk_rule.is_valid:
         return
     door_open = find_next_counter(door, best_counter, key_layout)
     ignored_doors = dict_intersection(best_counter.child_doors, door_open.child_doors)
@@ -482,11 +482,11 @@ def bk_restricted_rules(rule, door, odd_counter, empty_flag, key_counter, key_la
     post_counter = open_some_counter(door_open, key_layout, ignored_doors.keys())
     unique_loc = dict_difference(post_counter.free_locations, best_counter.free_locations)
     # todo: figure out the intention behind this change - better way to detect the big key is blocking needed key onlys?
-    if len(unique_loc) > 0:  # and bk_rule.is_valid
+    if len(unique_loc) > 0 and bk_rule.is_valid:
         rule.alternate_small_key = bk_rule.small_key_num
         rule.alternate_big_key_loc.update(unique_loc)
-    # elif not bk_rule.is_valid:
-    #     key_layout.key_logic.bk_restricted.update(unique_loc)
+    elif not bk_rule.is_valid:
+        key_layout.key_logic.bk_restricted.update(unique_loc)
 
 
 def open_a_door(door, child_state, flat_proposal):

--- a/Main.py
+++ b/Main.py
@@ -10,6 +10,7 @@ import zlib
 
 from BaseClasses import World, CollectionState, Item, Region, Location, Shop
 from Items import ItemFactory
+from KeyDoorShuffle import validate_key_placement
 from Regions import create_regions, create_shops, mark_light_world_regions, create_dungeon_regions
 from InvertedRegions import create_inverted_regions, mark_dark_world_regions
 from EntranceShuffle import link_entrances, link_inverted_entrances
@@ -131,6 +132,11 @@ def main(args, seed=None):
         fill_dungeons_restrictive(world, shuffled_locations)
     else:
         fill_dungeons(world)
+
+    for player in range(1, world.players+1):
+        for key_layout in world.key_layout[player].values():
+            if not validate_key_placement(key_layout, world, player):
+                raise RuntimeError("Keylock detected: %s (Player %d)" % (key_layout.sector.name, player))
 
     logger.info('Fill the world.')
 

--- a/Rom.py
+++ b/Rom.py
@@ -241,9 +241,9 @@ def patch_enemizer(world, player, rom, baserom_path, enemizercli, shufflepots, r
             'IcePalace': world.get_dungeon("Ice Palace", player).boss.enemizer_name,
             'MiseryMire': world.get_dungeon("Misery Mire", player).boss.enemizer_name,
             'TurtleRock': world.get_dungeon("Turtle Rock", player).boss.enemizer_name,
-            'GanonsTower1': world.get_dungeon('Ganons Tower', player).bosses['bottom'].enemizer_name,
-            'GanonsTower2': world.get_dungeon('Ganons Tower', player).bosses['middle'].enemizer_name,
-            'GanonsTower3': world.get_dungeon('Ganons Tower', player).bosses['top'].enemizer_name,
+            'GanonsTower1': [x for x in world.dungeons if x.player == player and 'bottom' in x.bosses.keys()][0].bosses['bottom'].enemizer_name,
+            'GanonsTower2': [x for x in world.dungeons if x.player == player and 'middle' in x.bosses.keys()][0].bosses['middle'].enemizer_name,
+            'GanonsTower3': [x for x in world.dungeons if x.player == player and 'top' in x.bosses.keys()][0].bosses['top'].enemizer_name,
             'GanonsTower4': 'Agahnim2',
             'Ganon': 'Ganon',
         }
@@ -612,10 +612,11 @@ def patch_rom(world, rom, player, team, enemized):
     for paired_door in world.paired_doors[player]:
         rom.write_bytes(paired_door.address_a(world, player), paired_door.rom_data_a(world, player))
         rom.write_bytes(paired_door.address_b(world, player), paired_door.rom_data_b(world, player))
-    for builder in world.dungeon_layouts[player].values():
-        if builder.pre_open_stonewall:
-            if builder.pre_open_stonewall.name == 'Desert Wall Slide NW':
-                dr_flags |= DROptions.Open_Desert_Wall
+    if world.doorShuffle[player] != 'vanilla':
+        for builder in world.dungeon_layouts[player].values():
+            if builder.pre_open_stonewall:
+                if builder.pre_open_stonewall.name == 'Desert Wall Slide NW':
+                    dr_flags |= DROptions.Open_Desert_Wall
     rom.write_byte(0x139006, dr_flags.value)
 
     # fix skull woods exit, if not fixed during exit patching


### PR DESCRIPTION
Introduce keylock checks after placing dungeon items.
This causes 25% of basic seeds to fail due to keylocks!