### PR TITLE
Fix triforce hunt logic

### DIFF
--- a/ItemList.py
+++ b/ItemList.py
@@ -196,7 +196,7 @@ def generate_itempool(world, player):
         region = world.get_region('Light World',player)
 
         loc = Location(player, "Murahdahla", parent=region)
-        loc.access_rule = lambda state: state.item_count('Triforce Piece', player) + state.item_count('Power Star', player) > state.world.treasure_hunt_count[player]
+        loc.access_rule = lambda state: state.item_count('Triforce Piece', player) + state.item_count('Power Star', player) >= state.world.treasure_hunt_count[player]
         region.locations.append(loc)
         world.dynamic_locations.append(loc)
 


### PR DESCRIPTION
Access to Murahdahla's Triforce requires ">" 20 triforce pieces by default. This leads to 21 pieces available in beatable only and it means a hard crash if one tries to set it to 30 out of 30, as has_beaten_game cannot find a 31st triforce piece to beat the game