### PR TITLE
Dungeon-Only option for important items

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1688,6 +1688,7 @@ class Spoiler(object):
                          'enemy_shuffle': self.world.enemy_shuffle,
                          'enemy_health': self.world.enemy_health,
                          'enemy_damage': self.world.enemy_damage,
+                         'dungeon_only': self.world.dungeon_only,
                          'players': self.world.players,
                          'teams': self.world.teams,
                          'experimental' : self.world.experimental
@@ -1748,6 +1749,7 @@ class Spoiler(object):
                 outfile.write('Enemy health:                    %s\n' % self.metadata['enemy_health'][player])
                 outfile.write('Enemy damage:                    %s\n' % self.metadata['enemy_damage'][player])
                 outfile.write('Hints:                           %s\n' % ('Yes' if self.metadata['hints'][player] else 'No'))
+                outfile.write('Dungeon-Only Progression:        %s\n' % ('Yes' if self.metadata['dungeon_only'][player] else 'No'))
                 outfile.write('Experimental:                    %s\n' % ('Yes' if self.metadata['experimental'][player] else 'No'))
             if self.doors:
                 outfile.write('\n\nDoors:\n\n')

--- a/CLI.py
+++ b/CLI.py
@@ -92,7 +92,7 @@ def parse_cli(argv, no_defaults=False):
             for name in ['logic', 'mode', 'swords', 'goal', 'difficulty', 'item_functionality',
                          'shuffle', 'door_shuffle', 'crystals_ganon', 'crystals_gt', 'openpyramid',
                          'mapshuffle', 'compassshuffle', 'keyshuffle', 'bigkeyshuffle', 'startinventory',
-                         'retro', 'accessibility', 'hints', 'beemizer', 'experimental', 'dungeon_counters',
+                         'retro', 'accessibility', 'hints', 'beemizer', 'dungeon_only', 'experimental', 'dungeon_counters',
                          'shufflebosses', 'shuffleenemies', 'enemy_health', 'enemy_damage', 'shufflepots',
                          'ow_palettes', 'uw_palettes', 'sprite', 'disablemusic', 'quickswap', 'fastmenu', 'heartcolor', 'heartbeep',
                          'remote_items']:
@@ -141,6 +141,7 @@ def parse_settings():
         "bigkeyshuffle": False,
         "keysanity": False,
         "door_shuffle": "basic",
+        "dungeon_only": False,
         "experimental": False,
         "dungeon_counters": "default",
 

--- a/DoorShuffle.py
+++ b/DoorShuffle.py
@@ -1318,6 +1318,7 @@ logical_connections = [
     ('Desert Main Lobby Right Path', 'Desert Right Alcove'),
     ('Desert Left Alcove Path', 'Desert Main Lobby'),
     ('Desert Right Alcove Path', 'Desert Main Lobby'),
+    ('Hera Big Chest Hook Path', 'Hera Big Chest Landing'),
     ('Hera Big Chest Landing Exit', 'Hera 4F'),
     ('PoD Pit Room Block Path N', 'PoD Pit Room Blocked'),
     ('PoD Pit Room Block Path S', 'PoD Pit Room'),

--- a/Doors.py
+++ b/Doors.py
@@ -261,6 +261,7 @@ def create_doors(world, player):
         create_door(player, 'Hera 4F Down Stairs', Sprl).dir(Dn, 0x27, 0, HTH).ss(S, 0x62, 0xc0),
         create_door(player, 'Hera 4F Up Stairs', Sprl).dir(Up, 0x27, 1, HTH).ss(A, 0x6b, 0x2c),
         create_door(player, 'Hera 4F Holes', Hole),
+        create_door(player, 'Hera Big Chest Hook Path', Lgcl),
         create_door(player, 'Hera Big Chest Landing Exit', Lgcl),
         create_door(player, 'Hera Big Chest Landing Holes', Hole),
         create_door(player, 'Hera 5F Down Stairs', Sprl).dir(Dn, 0x17, 1, HTH).ss(A, 0x62, 0x40),

--- a/Main.py
+++ b/Main.py
@@ -60,6 +60,7 @@ def main(args, seed=None, fish=None):
     world.enemy_health = args.enemy_health.copy()
     world.enemy_damage = args.enemy_damage.copy()
     world.beemizer = args.beemizer.copy()
+    world.dungeon_only = args.dungeon_only.copy()
     world.experimental = args.experimental.copy()
     world.dungeon_counters = args.dungeon_counters.copy()
     world.fish = fish
@@ -171,7 +172,6 @@ def main(args, seed=None, fish=None):
     elif args.algorithm == 'vt25':
         distribute_items_restrictive(world, False)
     elif args.algorithm == 'vt26':
-
         distribute_items_restrictive(world, True, shuffled_locations)
     elif args.algorithm == 'balanced':
         distribute_items_restrictive(world, True)
@@ -355,6 +355,7 @@ def copy_world(world):
     ret.compassshuffle = world.compassshuffle.copy()
     ret.keyshuffle = world.keyshuffle.copy()
     ret.bigkeyshuffle = world.bigkeyshuffle.copy()
+    ret.dungeon_only = world.dungeon_only.copy()
     ret.crystals_needed_for_ganon = world.crystals_needed_for_ganon.copy()
     ret.crystals_needed_for_gt = world.crystals_needed_for_gt.copy()
     ret.open_pyramid = world.open_pyramid.copy()

--- a/Mystery.py
+++ b/Mystery.py
@@ -150,6 +150,7 @@ def roll_settings(weights):
     door_shuffle = get_choice('door_shuffle')
     ret.door_shuffle = door_shuffle if door_shuffle != 'none' else 'vanilla'
     ret.experimental = get_choice('experimental') == 'on'
+    ret.dungeon_only = get_choice('dungeon_only') == 'on'
 
     ret.dungeon_counters = get_choice('dungeon_counters') if 'dungeon_counters' in weights else 'default'
     if ret.dungeon_counters == 'default':

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ a guaranteed Small Key still is. These items will be distributed according to th
 of the itempool will respect the algorithm setting. Music for dungeons is randomized so it cannot be used as a tell
 for which dungeons contain pendants and crystals; finding a Map for a dungeon will allow the overworld map to display its prize.
 
+## Dungeon-Only Progression Items
+
+This setting places Progression Items, Mail Upgrades and Heart Containers only in Dungeons. 11 Overworld Locations are also considered Dungeon Locations:
+Link's House, Sahasrahla, Pyramid Fairy (2), Lumberjack Tree, Pedestal, and 5 more depending on Mode:
+in Open/Standard/Retro: Uncle Tunnel (2) and Sahasrahla's Hut (3), and in Inverted: Hype Cave (5). The player always starts with 10 bombs.
+Only works with the balanced (default), vt26 and vt25 fill algorithms. If combined with Triforce Hunt, the goal is to collect 10 out of 15 Triforce Pieces.
+
 ## Retro
 
 This setting turns all Small Keys into universal Small Keys that can be used in any dungeon and are distributed across the world.

--- a/Regions.py
+++ b/Regions.py
@@ -316,7 +316,7 @@ def create_dungeon_regions(world, player):
         create_dungeon_region(player, 'Hera Beetles', 'Tower of Hera', None, ['Hera Beetles Down Stairs', 'Hera Beetles WS', 'Hera Beetles Holes']),
         create_dungeon_region(player, 'Hera Startile Corner', 'Tower of Hera', None, ['Hera Startile Corner ES', 'Hera Startile Corner NW', 'Hera Startile Corner Holes']),
         create_dungeon_region(player, 'Hera Startile Wide', 'Tower of Hera', None, ['Hera Startile Wide SW', 'Hera Startile Wide Up Stairs', 'Hera Startile Wide Holes']),
-        create_dungeon_region(player, 'Hera 4F', 'Tower of Hera', ['Tower of Hera - Compass Chest'], ['Hera 4F Down Stairs', 'Hera 4F Up Stairs', 'Hera 4F Holes']),
+        create_dungeon_region(player, 'Hera 4F', 'Tower of Hera', ['Tower of Hera - Compass Chest'], ['Hera 4F Down Stairs', 'Hera 4F Up Stairs', 'Hera Big Chest Hook Path', 'Hera 4F Holes']),
         create_dungeon_region(player, 'Hera Big Chest Landing', 'Tower of Hera', ['Tower of Hera - Big Chest'], ['Hera Big Chest Landing Exit', 'Hera Big Chest Landing Holes']),
         create_dungeon_region(player, 'Hera 5F', 'Tower of Hera', None, ['Hera 5F Down Stairs', 'Hera 5F Up Stairs', 'Hera 5F Star Hole', 'Hera 5F Pothole Chain', 'Hera 5F Normal Holes']),
         create_dungeon_region(player, 'Hera Fairies', 'Tower of Hera', None, ['Hera Fairies\' Warp']),

--- a/Rules.py
+++ b/Rules.py
@@ -159,6 +159,7 @@ def global_rules(world, player):
 
     # Tower of Hera
     set_rule(world.get_location('Tower of Hera - Big Key Chest', player), lambda state: state.has_fire_source(player))
+    set_rule(world.get_entrance('Hera Big Chest Hook Path', player), lambda state: state.has('Hookshot', player))
     set_defeat_dungeon_boss_rule(world.get_location('Tower of Hera - Boss', player))
     set_defeat_dungeon_boss_rule(world.get_location('Tower of Hera - Prize', player))
 

--- a/resources/app/cli/args.json
+++ b/resources/app/cli/args.json
@@ -212,6 +212,10 @@
     "dest": "hints",
     "help": "suppress"
   },
+  "dungeon_only": {
+    "action": "store_true",
+    "type": "bool"
+  },
   "heartbeep": {
     "choices": [
       "normal",

--- a/resources/app/cli/lang/en.json
+++ b/resources/app/cli/lang/en.json
@@ -253,6 +253,7 @@
       "None:           You will be able to reach enough locations to beat the game."
     ],
     "hints": [ "Make telepathic tiles and storytellers give helpful hints. (default: %(default)s)" ],
+    "dungeon_only": [ "Forces Progression Items, Mail Upgrades and Heart Containers in Dungeons and 11 selected Overworld Locations. (default: %(default)s)" ],
     "shuffleganon": [
       "Include the Ganon's Tower and Pyramid Hole in the",
       "entrance shuffle pool. (default: %(default)s)"

--- a/resources/app/gui/lang/en.json
+++ b/resources/app/gui/lang/en.json
@@ -66,6 +66,8 @@
     "randomizer.dungeon.dungeon_counters.on": "On",
     "randomizer.dungeon.dungeon_counters.pickup": "On Compass Pickup",
 
+    "randomizer.dungeon.dungeon_only": "Force Progression Items, Mail Upgrades and Heart Containers in Dungeons and 11 selected Overworld Locations",
+
 
     "randomizer.enemizer.potshuffle": "Pot Shuffle",
 

--- a/resources/app/gui/randomize/dungeon/widgets.json
+++ b/resources/app/gui/randomize/dungeon/widgets.json
@@ -19,6 +19,7 @@
         "on",
         "pickup"
       ]
-    }
+    },
+    "dungeon_only": { "type": "checkbox" }
   }
 }

--- a/source/classes/constants.py
+++ b/source/classes/constants.py
@@ -87,6 +87,7 @@ SETTINGSTOPROCESS = {
       "smallkeyshuffle": "keyshuffle",
       "bigkeyshuffle": "bigkeyshuffle",
       "dungeondoorshuffle": "door_shuffle",
+      "dungeon_only": "dungeon_only",
       "experimental": "experimental",
       "dungeon_counters": "dungeon_counters"
     },


### PR DESCRIPTION
This setting places Progression Items, Mail Upgrades and Heart Containers only in Dungeons. 11 Overworld Locations are also considered Dungeon Locations: Link's House, Sahasrahla, Pyramid Fairy (2), Lumberjack Tree, Pedestal, and 5 more depending on Mode: in Open/Standard/Retro: Uncle Tunnel (2) and Sahasrahla's Hut (3), and in Inverted: Hype Cave (5). The player always starts with 10 bombs. Only works with the balanced (default), vt26 and vt25 fill algorithms. If combined with Triforce Hunt, the goal is to collect 10 out of 15 Triforce Pieces (there wouldn't be enough locations otherwise).

Caveat: With Crossed Door Shuffle (which is the main intended use for this option), generation sometimes fails because the filler is running out of spots for (early) progression items. Some stats are included in this file (check bottom for summary): [DR DO Generation.txt](https://github.com/aerinon/ALttPDoorRandomizer/files/5050861/DR.DO.Generation.txt)

Not related to the above: The first commit adds a new edge for the Hera Big Chest with the Hookshot.