### PR TITLE
Portal fixes and adjustments

### DIFF
--- a/DoorShuffle.py
+++ b/DoorShuffle.py
@@ -398,7 +398,8 @@ def choose_portals(world, player):
         master_door_list = [x for x in world.doors if x.player == player and x.portalAble]
         portal_assignment = defaultdict(list)
         shuffled_info = list(info_map.items())
-        random.shuffle(shuffled_info)
+        if cross_flag:
+            random.shuffle(shuffled_info)
         for dungeon, info in shuffled_info:
             outstanding_portals = list(dungeon_portals[dungeon])
             hc_flag = std_flag and dungeon == 'Hyrule Castle'

--- a/DoorShuffle.py
+++ b/DoorShuffle.py
@@ -67,7 +67,7 @@ def link_doors_main(world, player):
         for entrance, ext in ladders:
             connect_two_way(world, entrance, ext, player)
 
-    if world.intensity[player] < 3 or world.doorShuffle == 'vanilla':
+    if world.intensity[player] < 3 or world.doorShuffle[player] == 'vanilla':
         mirror_route = world.get_entrance('Sanctuary Mirror Route', player)
         mr_door = mirror_route.door
         sanctuary = mirror_route.parent_region
@@ -397,7 +397,9 @@ def choose_portals(world, player):
 
         master_door_list = [x for x in world.doors if x.player == player and x.portalAble]
         portal_assignment = defaultdict(list)
-        for dungeon, info in info_map.items():
+        shuffled_info = list(info_map.items())
+        random.shuffle(shuffled_info)
+        for dungeon, info in shuffled_info:
             outstanding_portals = list(dungeon_portals[dungeon])
             hc_flag = std_flag and dungeon == 'Hyrule Castle'
             if hc_flag:
@@ -543,7 +545,7 @@ def find_portal_candidates(door_list, dungeon, need_passage=False, dead_end_allo
                            bk_shuffle=False, standard=False):
     ret = [x for x in door_list if bk_shuffle or not x.bk_shuffle_req]
     if crossed:
-        ret = [x for x in ret if not x.dungeonLink or x.entrance.parent_region.dungeon.name == dungeon]
+        ret = [x for x in ret if not x.dungeonLink or x.dungeonLink == dungeon or x.dungeonLink.startswith('link')]
     else:
         ret = [x for x in ret if x.entrance.parent_region.dungeon.name == dungeon]
     if need_passage:

--- a/Doors.py
+++ b/Doors.py
@@ -1312,12 +1312,7 @@ def create_doors(world, player):
     # can't unlink from skull woods right now
     world.get_door('Skull 2 West Lobby S', player).dungeonLink = 'Skull Woods'
 
-    world.get_door('Ice Spike Cross SE', player).dungeonLink = 'linkIceFalls'
-    world.get_door('Ice Tall Hint SE', player).dungeonLink = 'linkIceFalls'
-    world.get_door('Ice Switch Room SE', player).dungeonLink = 'linkIceFalls'
-
-    world.get_door('Ice Cross Bottom SE', player).dungeonLink = 'linkIceFalls2'
-    world.get_door('Ice Conveyor SW', player).dungeonLink = 'linkIceFalls2'
+    set_special_dungeon_links(world, player)
 
 
 def create_portals(world, player):
@@ -1351,10 +1346,21 @@ def create_portals(world, player):
     world.dungeon_portals[player] += dungeon_portals
 
 
+def set_special_dungeon_links(world, player):
+    world.get_door('Ice Spike Cross SE', player).dungeonLink = 'linkIceFalls'
+    world.get_door('Ice Tall Hint SE', player).dungeonLink = 'linkIceFalls'
+    world.get_door('Ice Switch Room SE', player).dungeonLink = 'linkIceFalls'
+
+    world.get_door('Ice Cross Bottom SE', player).dungeonLink = 'linkIceFalls2'
+    world.get_door('Ice Conveyor SW', player).dungeonLink = 'linkIceFalls2'
+
+
 def reset_portals(world, player):
     world.dungeon_portals[player].clear()
     world._portal_cache.clear()
     create_portals(world, player)
+    set_special_dungeon_links(world, player)
+
 
 def create_paired_doors(world, player):
     world.paired_doors[player] = [


### PR DESCRIPTION
This fixes 2 bugs with portals. One of them caused 5 of the Ice Palace doors to only ever appear as portals in Ice Palace itself.

In addition, shuffles the dungeon order before choosing the dungeon lobbies in Crossed. This is because dungeons later in the list are more likely to have vanilla rooms or dead ends as lobbies and this new shuffling makes that bias less predictable.