### PR TITLE
Solves Trench 2 illogical break

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ weights/
 /MultiMystery/
 /Players/
 /QUsb2Snes/
+/output/
 
 resources/user/*
 !resources/user/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ get-pip.py
 venv
 test
 data/base2current.json
+*.zspr

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -592,7 +592,7 @@ class CollectionState(object):
             flood_location = world.get_location(flooded_keys[location.name], location.player)
             item = flood_location.item
             item_is_important = False if not item else item.advancement or item.bigkey or item.smallkey
-            return flood_location in self.locations_checked or not item_is_important or location.parent_region.name is not 'Swamp Trench 2 Alcove'
+            return flood_location in self.locations_checked or not item_is_important or location.parent_region.name not 'Swamp Trench 2 Alcove'
         return True
 
     def has(self, item, player, count=1):

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -592,7 +592,7 @@ class CollectionState(object):
             flood_location = world.get_location(flooded_keys[location.name], location.player)
             item = flood_location.item
             item_is_important = False if not item else item.advancement or item.bigkey or item.smallkey
-            return flood_location in self.locations_checked or not item_is_important or location.parent_region.name != 'Swamp Trench 2 Alcove'
+            return flood_location in self.locations_checked or not item_is_important or location.parent_region.name not in ['Swamp Trench 1 Alcove', 'Swamp Trench 2 Alcove']
         return True
 
     def has(self, item, player, count=1):

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -592,7 +592,7 @@ class CollectionState(object):
             flood_location = world.get_location(flooded_keys[location.name], location.player)
             item = flood_location.item
             item_is_important = False if not item else item.advancement or item.bigkey or item.smallkey
-            return flood_location in self.locations_checked or not item_is_important
+            return flood_location in self.locations_checked or not item_is_important or location.parent_region.name is not 'Swamp Trench 2 Alcove'
         return True
 
     def has(self, item, player, count=1):

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -592,7 +592,7 @@ class CollectionState(object):
             flood_location = world.get_location(flooded_keys[location.name], location.player)
             item = flood_location.item
             item_is_important = False if not item else item.advancement or item.bigkey or item.smallkey
-            return flood_location in self.locations_checked or not item_is_important or location.parent_region.name not 'Swamp Trench 2 Alcove'
+            return flood_location in self.locations_checked or not item_is_important or location.parent_region.name != 'Swamp Trench 2 Alcove'
         return True
 
     def has(self, item, player, count=1):


### PR DESCRIPTION
Whenever a progression item is placed on the Big Key ledge or the Trench Departure, the algorithm can't pick it up before the trench is flooded, but it can't flood the trench because the item needs to be picked up before that happens.
This seems break 10-15% of vanillla doors with potshuffle that has retro and/or keydropshuffle.

The solution is to add a check to confirm that the potkey item is actually in the trench or not while deciding if it is floodable.