### PR TITLE
TFH playthrough fix

### DIFF
--- a/ItemList.py
+++ b/ItemList.py
@@ -283,7 +283,7 @@ def generate_itempool(world, player):
                     if not found_sword and world.swords[player] != 'swordless':
                         found_sword = True
                         possible_weapons.append(item)
-                if item in ['Progressive Bow', 'Bow'] and not found_bow:
+                if item in ['Progressive Bow', 'Bow'] and not found_bow and not world.retro[player]:
                     found_bow = True
                     possible_weapons.append(item)
                 if item in ['Hammer', 'Fire Rod', 'Cane of Somaria', 'Cane of Byrna']:

--- a/ItemList.py
+++ b/ItemList.py
@@ -196,7 +196,6 @@ def generate_itempool(world, player):
         region = world.get_region('Light World',player)
 
         loc = Location(player, "Murahdahla", parent=region)
-        loc.access_rule = lambda state: state.item_count('Triforce Piece', player) + state.item_count('Power Star', player) >= state.world.treasure_hunt_count[player]
         region.locations.append(loc)
         world.dynamic_locations.append(loc)
 

--- a/Rules.py
+++ b/Rules.py
@@ -41,6 +41,8 @@ def set_rules(world, player):
     elif world.goal[player] == 'ganon':
         # require aga2 to beat ganon
         add_rule(world.get_location('Ganon', player), lambda state: state.has('Beat Agahnim 2', player))
+    elif world.goal[player] == 'triforcehunt':
+        add_rule(world.get_location('Murahdahla', player), lambda state: state.item_count('Triforce Piece', player) + state.item_count('Power Star', player) >= state.world.treasure_hunt_count[player])
 
     if world.mode[player] != 'inverted':
         set_big_bomb_rules(world, player)


### PR DESCRIPTION
copy_world overwrites Murahdahla's logic and needs to be reset through set_rules to work properly. It make sense to me to have the access rule to Murah in the same place as the other rules.

Second commit fixes a problem with Retro+Standard+ Bow on uncle failing to generate because you can't use bow until you buy your arrow.