### PR TITLE
Reimplement --securerandom

### DIFF
--- a/Bosses.py
+++ b/Bosses.py
@@ -1,5 +1,5 @@
 import logging
-import random
+import RaceRandom as random
 
 from BaseClasses import Boss
 from Fill import FillError

--- a/DoorShuffle.py
+++ b/DoorShuffle.py
@@ -1,4 +1,4 @@
-import random
+import RaceRandom as random
 from collections import defaultdict, deque
 import logging
 import operator as op

--- a/DungeonGenerator.py
+++ b/DungeonGenerator.py
@@ -1,4 +1,4 @@
-import random
+import RaceRandom as random
 import collections
 import itertools
 from collections import defaultdict, deque

--- a/DungeonRandomizer.py
+++ b/DungeonRandomizer.py
@@ -3,7 +3,7 @@ import argparse
 import copy
 import os
 import logging
-import random
+import RaceRandom as random
 import textwrap
 import shlex
 import sys

--- a/Dungeons.py
+++ b/Dungeons.py
@@ -1,4 +1,4 @@
-import random
+import RaceRandom as random
 
 from BaseClasses import Dungeon
 from Bosses import BossFactory

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -1,4 +1,4 @@
-import random
+import RaceRandom as random
 
 # ToDo: With shuffle_ganon option, prevent gtower from linking to an exit only location through a 2 entrance cave.
 from collections import defaultdict

--- a/Fill.py
+++ b/Fill.py
@@ -1,4 +1,4 @@
-import random
+import RaceRandom as random
 import logging
 
 from BaseClasses import CollectionState

--- a/ItemList.py
+++ b/ItemList.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 import logging
 import math
-import random
+import RaceRandom as random
 
 from BaseClasses import Region, RegionType, Shop, ShopType, Location, CollectionState
 from Bosses import place_bosses

--- a/Main.py
+++ b/Main.py
@@ -4,7 +4,8 @@ from itertools import zip_longest
 import json
 import logging
 import os
-import random
+import RaceRandom as random
+import string
 import time
 import zlib
 
@@ -41,8 +42,8 @@ def main(args, seed=None, fish=None):
 
     start = time.perf_counter()
 
-    # if args.securerandom:
-    #     random.use_secure()
+    if args.securerandom:
+        random.use_secure()
 
     # initialize the world
     if args.code:
@@ -61,7 +62,7 @@ def main(args, seed=None, fish=None):
     random.seed(world.seed)
 
     if args.securerandom:
-        world.seed = None
+        world.seed = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(9))
 
     world.remote_items = args.remote_items.copy()
     world.mapshuffle = args.mapshuffle.copy()
@@ -332,7 +333,7 @@ def main(args, seed=None, fish=None):
     logger.info(world.fish.translate("cli","cli","made.playthrough") % (YES if (args.calc_playthrough) else NO))
     logger.info(world.fish.translate("cli","cli","made.spoiler") % (YES if (not args.jsonout and args.create_spoiler) else NO))
     logger.info(world.fish.translate("cli","cli","used.enemizer") % (YES if enemized else NO))
-    logger.info(world.fish.translate("cli","cli","seed") + ": %d", world.seed)
+    logger.info(world.fish.translate("cli","cli","seed") + ": %s", world.seed)
     logger.info(world.fish.translate("cli","cli","total.time"), time.perf_counter() - start)
 
 #    print_wiki_doors_by_room(dungeon_regions,world,1)

--- a/Mystery.py
+++ b/Mystery.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-import random
+import RaceRandom as random
 import urllib.request
 import urllib.parse
 import yaml

--- a/Plando.py
+++ b/Plando.py
@@ -3,7 +3,7 @@ import argparse
 import hashlib
 import logging
 import os
-import random
+import RaceRandom as random
 import time
 import sys
 

--- a/PotShuffle.py
+++ b/PotShuffle.py
@@ -275,7 +275,7 @@ vanilla_pots = {
 
 
 def shuffle_pots(world, player):
-    import random
+    import RaceRandom as random
 
     new_pot_contents = {}
 

--- a/Rom.py
+++ b/Rom.py
@@ -5,7 +5,7 @@ import json
 import hashlib
 import logging
 import os
-import random
+import RaceRandom as random
 import struct
 import sys
 import subprocess
@@ -1542,8 +1542,9 @@ def patch_rom(world, rom, player, team, enemized, is_mystery=False):
     # set rom name
     # 21 bytes
     from Main import __version__
+    seedstring = f'{world.seed:09}' if isinstance(world.seed, int) else world.seed
     # todo: change to DR when Enemizer is okay with DR
-    rom.name = bytearray(f'ER{__version__.split("-")[0].replace(".","")[0:3]}_{team+1}_{player}_{world.seed:09}\0', 'utf8')[:21]
+    rom.name = bytearray(f'ER{__version__.split("-")[0].replace(".","")[0:3]}_{team+1}_{player}_{seedstring}\0', 'utf8')[:21]
     rom.name.extend([0] * (21 - len(rom.name)))
     rom.write_bytes(0x7FC0, rom.name)
 

--- a/resources/app/cli/lang/de.json
+++ b/resources/app/cli/lang/de.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "app.title": "ALttP Tür Randomisier Version %s - Nummer: %d, Code: %s",
+    "app.title": "ALttP Tür Randomisier Version %s - Nummer: %s, Code: %s",
     "shuffling.world": "Welt wird durchmischt.",
     "generating.itempool": "Generier Gegenstandsbasis.",
     "calc.access.rules": "Berechne Zugriffsregeln.",

--- a/resources/app/cli/lang/en.json
+++ b/resources/app/cli/lang/en.json
@@ -2,7 +2,7 @@
   "cli": {
     "yes": "Yes",
     "no": "No",
-    "app.title": "ALttP Door Randomizer Version %s - Seed: %d, Code: %s",
+    "app.title": "ALttP Door Randomizer Version %s - Seed: %s, Code: %s",
     "version": "Version",
     "seed": "Seed",
     "player": "Player",

--- a/resources/app/cli/lang/es.json
+++ b/resources/app/cli/lang/es.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "app.title": "ALttP Puerta Aleatorizador Versión %s - Número: %d, Código: %s",
+    "app.title": "ALttP Puerta Aleatorizador Versión %s - Número: %s, Código: %s",
     "player": "Jugador",
     "shuffling.world": "Barajando el Mundo",
     "shuffling.dungeons": "Barajando Mazmorras",


### PR DESCRIPTION
Seeds should be reprodicable without the flag passed, and unreproducible with the flag passed.
With `--securerandom`, generate a 9-char alphanumeric string to use as seed to make filenames differ.