### PR TITLE
Extra warnings / checks

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -24,6 +24,13 @@ from source.classes.BabelFish import BabelFish
 from source.classes.Empty import Empty
 
 
+def check_python_version():
+    import sys
+    version = sys.version_info
+    if version.major < 3 or version.minor < 7:
+        messagebox.showinfo("Door Shuffle " + ESVersion, 'Door Rando may have issues with python versions earlier than 3.7.  Detected version: %s' % sys.version)
+
+
 def guiMain(args=None):
     # Save settings to file
     def save_settings(args):
@@ -187,6 +194,8 @@ def guiMain(args=None):
 
     # load adjust settings into options
     loadadjustargs(self, self.settings)
+
+    check_python_version()
 
     # run main window
     mainWindow.mainloop()

--- a/Gui.py
+++ b/Gui.py
@@ -24,11 +24,11 @@ from source.classes.BabelFish import BabelFish
 from source.classes.Empty import Empty
 
 
-def check_python_version():
+def check_python_version(fish):
     import sys
     version = sys.version_info
     if version.major < 3 or version.minor < 7:
-        messagebox.showinfo("Door Shuffle " + ESVersion, 'Door Rando may have issues with python versions earlier than 3.7.  Detected version: %s' % sys.version)
+        messagebox.showinfo("Door Shuffle " + ESVersion, fish.translate("cli","cli","old.python.version") % sys.version)
 
 
 def guiMain(args=None):
@@ -195,7 +195,7 @@ def guiMain(args=None):
     # load adjust settings into options
     loadadjustargs(self, self.settings)
 
-    check_python_version()
+    check_python_version(self.fish)
 
     # run main window
     mainWindow.mainloop()

--- a/Main.py
+++ b/Main.py
@@ -34,7 +34,15 @@ class EnemizerError(RuntimeError):
     pass
 
 
+def check_python_version():
+    import sys
+    version = sys.version_info
+    if version.major < 3 or version.minor < 7:
+        logging.warning('Door Rando may have issues with python versions earlier than 3.7.  Detected version: %s', sys.version)
+
+
 def main(args, seed=None, fish=None):
+    check_python_version()
     if args.outputpath:
         os.makedirs(args.outputpath, exist_ok=True)
         output_path.cached_path = args.outputpath
@@ -257,11 +265,11 @@ def main(args, seed=None, fish=None):
                 rom = JsonRom() if args.jsonout or use_enemizer else LocalRom(args.rom)
 
                 if use_enemizer and (args.enemizercli or not args.jsonout):
-                    base_patch = LocalRom(args.rom)  # update base2current.json (side effect)
+                    local_rom = LocalRom(args.rom)  # update base2current.json (side effect)
                     if args.rom and not(os.path.isfile(args.rom)):
                         raise RuntimeError("Could not find valid base rom for enemizing at expected path %s." % args.rom)
                     if os.path.exists(args.enemizercli):
-                        patch_enemizer(world, player, rom, args.rom, args.enemizercli, sprite_random_on_hit)
+                        patch_enemizer(world, player, rom, local_rom, args.enemizercli, sprite_random_on_hit)
                         enemized = True
                         if not args.jsonout:
                             rom = LocalRom.fromJsonRom(rom, args.rom, 0x400000)

--- a/Main.py
+++ b/Main.py
@@ -29,6 +29,8 @@ from Utils import output_path, parse_player_names
 
 __version__ = '0.4.0.11u'
 
+from source.classes.BabelFish import BabelFish
+
 
 class EnemizerError(RuntimeError):
     pass
@@ -38,7 +40,7 @@ def check_python_version():
     import sys
     version = sys.version_info
     if version.major < 3 or version.minor < 7:
-        logging.warning('Door Rando may have issues with python versions earlier than 3.7.  Detected version: %s', sys.version)
+        logging.warning(BabelFish().translate("cli","cli","old.python.version"), sys.version)
 
 
 def main(args, seed=None, fish=None):

--- a/Rules.py
+++ b/Rules.py
@@ -1149,7 +1149,7 @@ def standard_rules(world, player):
             set_rule(entrance, lambda state: state.has('Zelda Delivered', player))
     set_rule(world.get_entrance('Sanctuary Exit', player), lambda state: state.has('Zelda Delivered', player))
     # zelda should be saved before agahnim is in play
-    set_rule(world.get_location('Agahnim 1', player), lambda state: state.has('Zelda Delivered', player))
+    add_rule(world.get_location('Agahnim 1', player), lambda state: state.has('Zelda Delivered', player))
 
     # too restrictive for crossed?
     def uncle_item_rule(item):

--- a/resources/app/cli/lang/en.json
+++ b/resources/app/cli/lang/en.json
@@ -52,7 +52,8 @@
     "enemizer.nothing.applied": "No Enemizer options will be applied until this is resolved.",
     "building.collection.spheres": "Building up collection spheres",
     "building.calculating.spheres": "Calculated sphere %i, containing %i of %i progress items.",
-    "building.final.spheres": "Calculated final sphere %i, containing %i of %i progress items."
+    "building.final.spheres": "Calculated final sphere %i, containing %i of %i progress items.",
+    "old.python.version": "Door Rando may have issues with python versions earlier than 3.7.  Detected version: %s"
   },
   "help": {
     "lang": [ "App Language, if available, defaults to English" ],


### PR DESCRIPTION
Handle headered roms for enemizer by stripping the header before calling it
Add a warning for python 3.6 and earlier, because that's been known to cause issues.

Also fixes a bit of standard logic for defeating Aga1.