### PR TITLE
Define bomb upgrade as advancement before beemizer

### DIFF
--- a/ItemList.py
+++ b/ItemList.py
@@ -301,6 +301,11 @@ def generate_itempool(world, player):
         world.get_location(location, player).event = True
         world.get_location(location, player).locked = True
 
+    if world.bomblogic[player]:
+        for item in world.itempool:
+            if item.name == 'Bomb Upgrade (+10)' and item.player == player:
+                item.advancement = True
+
     if world.shopsanity[player]:
         for shop in world.shops[player]:
             if shop.region.name in shop_to_location_table:
@@ -524,9 +529,6 @@ def set_up_shops(world, player):
             cap_shop = world.get_region('Capacity Upgrade', player).shop
             cap_shop.inventory[1] = None  # remove arrow capacity upgrades in retro
     if world.bomblogic[player]:
-        for item in world.itempool:
-            if item.name == 'Bomb Upgrade (+10)' and item.player == player:
-                item.advancement = True
         if world.shopsanity[player]:
             removals = [item for item in world.itempool if item.name == 'Bomb Upgrade (+5)' and item.player == player]
             for remove in removals:

--- a/ItemList.py
+++ b/ItemList.py
@@ -301,11 +301,6 @@ def generate_itempool(world, player):
         world.get_location(location, player).event = True
         world.get_location(location, player).locked = True
 
-    if world.bomblogic[player]:
-        for item in world.itempool:
-            if item.name == 'Bomb Upgrade (+10)' and item.player == player:
-                item.advancement = True
-
     if world.shopsanity[player]:
         for shop in world.shops[player]:
             if shop.region.name in shop_to_location_table:
@@ -322,6 +317,11 @@ def generate_itempool(world, player):
         for potion in ['Green Potion', 'Blue Potion', 'Red Potion']:
             p_item = next(item for item in items if item.name == potion and item.player == player)
             p_item.priority = True  # don't beemize one of each potion
+
+    if world.bomblogic[player]:
+        for item in items:
+            if item.name == 'Bomb Upgrade (+10)' and item.player == player:
+                item.advancement = True
 
     world.lamps_needed_for_dark_rooms = lamps_needed_for_dark_rooms
 


### PR DESCRIPTION
Beemizer frivolously replaces bomb upgrades and need to be reeled in a bit by setting advancement earlier