### PR TITLE
Fix standard + partitioned door shuffle

### DIFF
--- a/DoorShuffle.py
+++ b/DoorShuffle.py
@@ -2690,8 +2690,12 @@ def find_valid_bd_combination(builder, suggested, world, player):
         test = random.choice([True, False])
         if test:
             bomb_doors_needed -= 1
+            if bomb_doors_needed < 0:
+                bomb_doors_needed = 0
         else:
             dash_doors_needed -= 1
+            if dash_doors_needed < 0:
+                dash_doors_needed = 0
     bomb_proposal = random.sample(bd_door_pool, k=bomb_doors_needed)
     bomb_proposal.extend(custom_bomb_doors)
     dash_pool = [x for x in bd_door_pool if x not in bomb_proposal]

--- a/DungeonGenerator.py
+++ b/DungeonGenerator.py
@@ -1335,8 +1335,9 @@ def create_dungeon_builders(all_sectors, connections_tuple, world, player, dunge
                         sector = find_sector(r_name, all_sectors)
                     reverse_d_map[sector] = key
         if world.mode[player] == 'standard':
-            current_dungeon = dungeon_map['Hyrule Castle']
-            standard_stair_check(dungeon_map, current_dungeon, candidate_sectors, global_pole)
+            if 'Hyrule Castle' in dungeon_map:
+                current_dungeon = dungeon_map['Hyrule Castle']
+                standard_stair_check(dungeon_map, current_dungeon, candidate_sectors, global_pole)
 
         complete_dungeons = {x: y for x, y in dungeon_map.items() if sum(len(sector.outstanding_doors) for sector in y.sectors) <= 0}
         [dungeon_map.pop(key) for key in complete_dungeons.keys()]


### PR DESCRIPTION
The combination of standard start and partitioned door shuffle was failing to generate, because it looked for Hyrule Castle in every partition.

Also includes a fix to the case where it would try to generate a negative number of bomb doors or dash doors.