### PR TITLE
remove hard requirement of tkinter when using CLI

### DIFF
--- a/source/meta/check_requirements.py
+++ b/source/meta/check_requirements.py
@@ -1,6 +1,4 @@
 import importlib.util
-import webbrowser
-from tkinter import Tk, Label, Button, Frame
 
 
 def check_requirements(console=False):
@@ -26,6 +24,9 @@ def check_requirements(console=False):
             logger.error('See the step about "Installing Platform-specific dependencies":')
             logger.error('https://github.com/aerinon/ALttPDoorRandomizer/blob/DoorDev/docs/BUILDING.md')
         else:
+            import webbrowser
+            from tkinter import Tk, Label, Button, Frame
+
             master = Tk()
             master.title('Error')
             frame = Frame(master)


### PR DESCRIPTION
This moves the import of tkinter and webbrowser to be inside of the GUI-version of this function.  This will allow the script to work on machines without a GUI (and thus don't have tkinter installed).