### PR TITLE
Enable `settingsfile` for multiworld generation

### DIFF
--- a/CLI.py
+++ b/CLI.py
@@ -122,6 +122,11 @@ def parse_cli(argv, no_defaults=False):
         defaults = copy.deepcopy(ret)
         for player in range(1, player_num + 1):
             playerargs = parse_cli(shlex.split(getattr(ret, f"p{player}")), True)
+            
+            if playerargs.filename:
+                playersettings = apply_settings_file({}, playerargs.filename)
+                for k, v in playersettings.items():
+                    setattr(playerargs, k, v)
 
             for name in ['logic', 'mode', 'swords', 'goal', 'difficulty', 'item_functionality',
                          'flute_mode', 'bow_mode', 'take_any', 'boots_hint',


### PR DESCRIPTION
This allows usage of commands such as `py DungeonRandomizer.py --multi 2 --p1 "--settingsfile p1.json" --p2 "--settingsfile p2.json"` .

Extra parameters specified in the player specific options will _not_ overwrite the settingsfile.

This uses an option that's marked for backwards compatibility, but it seems to work fine.