### PR TITLE
Remove a bad triforce text

### DIFF
--- a/Text.py
+++ b/Text.py
@@ -91,7 +91,6 @@ Triforce_texts = [
     'Who stole the fourth triangle?',
     'Trifource?\nMore Like Tritrice, am I right?'
     '\n    Well Done!',
-    'You just wasted 2 hours of your life.',
     'This was meant to be a trapezoid',
     # these ones are from web randomizer
     "\n       G G",


### PR DESCRIPTION
It was brought up on the ALTTPR Discord that this Triforce text can feel really bad to see at the end of a long race.  I think it's best we give it a permanent vacation.