### PR TITLE
MultiServer: Add option to MultiServer to disable client forfeits

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -285,9 +285,9 @@ async def process_client_cmd(ctx : Context, client : Client, cmd, args):
             notify_all(ctx, get_connected_players_string(ctx))
         if args.startswith('!forfeit'):
             if ctx.disable_client_forfeit:
-                notify_client(client, 'Forfeit is currently disabled server-side.')
-                return
-            forfeit_player(ctx, client.team, client.slot)
+                notify_client(client, 'Client-initiated forfeits are disabled.  Please ask the host of this game to forfeit on your behalf.')
+            else:
+                forfeit_player(ctx, client.team, client.slot)
         if args.startswith('!countdown'):
             try:
                 timer = int(args.split()[1])

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -46,6 +46,9 @@ class Context:
         self.lookup_name_to_id = {}
         self.lookup_id_to_name = {}
 
+        self.disable_client_forfeit = False
+
+
 async def send_msgs(websocket, msgs):
     if not websocket or not websocket.open or websocket.closed:
         return
@@ -281,6 +284,9 @@ async def process_client_cmd(ctx : Context, client : Client, cmd, args):
         if args.startswith('!players'):
             notify_all(ctx, get_connected_players_string(ctx))
         if args.startswith('!forfeit'):
+            if ctx.disable_client_forfeit:
+                notify_client(client, 'Forfeit is currently disabled server-side.')
+                return
             forfeit_player(ctx, client.team, client.slot)
         if args.startswith('!countdown'):
             try:


### PR DESCRIPTION
The purpose of this change is to allow client-side forfeits to be disabled.  The primary use case for this would be for races.