### PR TITLE
Triforce Pieces Min and Max settings work everywhere

### DIFF
--- a/CLI.py
+++ b/CLI.py
@@ -229,7 +229,7 @@ def parse_settings():
         "triforce_pool_max": 0,
         "triforce_goal_min": 0,
         "triforce_goal_max": 0,
-        "triforce_min_difference": 10,
+        "triforce_min_difference": 0,
 
         "code": "",
         "multi": 1,

--- a/CLI.py
+++ b/CLI.py
@@ -132,7 +132,7 @@ def parse_cli(argv, no_defaults=False):
                          'flute_mode', 'bow_mode', 'take_any', 'boots_hint',
                          'shuffle', 'door_shuffle', 'intensity', 'crystals_ganon', 'crystals_gt', 'openpyramid',
                          'mapshuffle', 'compassshuffle', 'keyshuffle', 'bigkeyshuffle', 'startinventory',
-                         'usestartinventory', 'bombbag', 'overworld_map', 'restrict_boss_items',
+                         'usestartinventory', 'bombbag', 'overworld_map', 'restrict_boss_items', 'triforce_max_difference',
                          'triforce_pool_min', 'triforce_pool_max', 'triforce_goal_min', 'triforce_goal_max',
                          'triforce_min_difference', 'triforce_goal', 'triforce_pool', 'shufflelinks', 'shuffletavern',
                          'pseudoboots', 'retro', 'accessibility', 'hints', 'beemizer', 'experimental', 'dungeon_counters',
@@ -230,6 +230,7 @@ def parse_settings():
         "triforce_goal_min": 0,
         "triforce_goal_max": 0,
         "triforce_min_difference": 0,
+        "triforce_max_difference": 10000,
 
         "code": "",
         "multi": 1,

--- a/Main.py
+++ b/Main.py
@@ -146,7 +146,7 @@ def main(args, seed=None, fish=None):
             if int(args.triforce_pool[p]) != 0:
                 world.treasure_hunt_total[p] = int(args.triforce_pool[p])
             elif int(args.triforce_pool_min[p]) != 0 and int(args.triforce_pool_max[p]) != 0:
-                world.treasure_hunt_total[p] = random.randint(max(int(args.triforce_pool_min[p]), world.treasure_hunt_count[p] + int(args.triforce_min_difference[p])), int(args.triforce_pool_max[p]))
+                world.treasure_hunt_total[p] = random.randint(max(int(args.triforce_pool_min[p]), world.treasure_hunt_count[p] + int(args.triforce_min_difference[p])), min(int(args.triforce_pool_max[p]), world.treasure_hunt_count[p] + int(args.triforce_max_difference[p])))
             else:
                 world.treasure_hunt_total[p] = 10 if world.goal[p] == 'trinity' else 30
         else:

--- a/Main.py
+++ b/Main.py
@@ -124,8 +124,6 @@ def main(args, seed=None, fish=None):
     world.potshuffle = args.shufflepots.copy()
     world.mixed_travel = args.mixed_travel.copy()
     world.standardize_palettes = args.standardize_palettes.copy()
-    world.treasure_hunt_count = {k: int(v) for k, v in args.triforce_goal.items()}
-    world.treasure_hunt_total = {k: int(v) for k, v in args.triforce_pool.items()}
     world.shufflelinks = args.shufflelinks.copy()
     world.shuffletavern = args.shuffletavern.copy()
     world.pseudoboots = args.pseudoboots.copy()
@@ -134,6 +132,26 @@ def main(args, seed=None, fish=None):
     world.restrict_boss_items = args.restrict_boss_items.copy()
     world.collection_rate = args.collection_rate.copy()
     world.colorizepots = args.colorizepots.copy()
+
+    world.treasure_hunt_count = {}
+    world.treasure_hunt_total = {}
+    for p in args.triforce_goal:
+        if int(args.triforce_goal[p]) != 0 or int(args.triforce_pool[p]) != 0 or int(args.triforce_goal_min[p]) != 0 or int(args.triforce_goal_max[p]) != 0 or int(args.triforce_pool_min[p]) != 0 or int(args.triforce_pool_max[p]) != 0:
+            if int(args.triforce_goal[p]) != 0:
+                world.treasure_hunt_count[p] = int(args.triforce_goal[p])
+            elif int(args.triforce_goal_min[p]) != 0 and int(args.triforce_goal_max[p]) != 0:
+                world.treasure_hunt_count[p] = random.randint(int(args.triforce_goal_min[p]), int(args.triforce_goal_max[p]))
+            else:
+                world.treasure_hunt_count[p] = 8 if world.goal[p] == 'trinity' else 20
+            if int(args.triforce_pool[p]) != 0:
+                world.treasure_hunt_total[p] = int(args.triforce_pool[p])
+            elif int(args.triforce_pool_min[p]) != 0 and int(args.triforce_pool_max[p]) != 0:
+                world.treasure_hunt_total[p] = random.randint(max(int(args.triforce_pool_min[p]), world.treasure_hunt_count[p] + int(args.triforce_min_difference[p])), int(args.triforce_pool_max[p]))
+            else:
+                world.treasure_hunt_total[p] = 10 if world.goal[p] == 'trinity' else 30
+        else:
+            # this will be handled in ItemList.py and custom item pool is used to determine the numbers
+            world.treasure_hunt_count[p], world.treasure_hunt_total[p] = 0, 0
 
     world.rom_seeds = {player: random.randint(0, 999999999) for player in range(1, world.players + 1)}
     world.finish_init()

--- a/README.md
+++ b/README.md
@@ -573,13 +573,14 @@ Create bps patch(es) instead of generating rom(s) for distribution. `--bps`
 
 ### Triforce Hunt Settings
 
-A collection of settings to control the triforce piece pool for the CLI/Mystery
+A collection of settings to control the triforce piece pool if not specified through --triforce_goal and --triforce_pool
 
 * --triforce_goal_min: Minimum number of pieces to collect to win
 * --triforce_goal_max: Maximum number of pieces to collect to win
 * --triforce_pool_min: Minimum number of pieces in item pool
 * --triforce_pool_max: Maximum number of pieces in item pool
 * --triforce_min_difference: Minimum difference between pool and goal to win
+* --triforce_max_difference: Maximum difference between pool and goal to win
 
 ### Seed
 

--- a/mystery_example.yml
+++ b/mystery_example.yml
@@ -107,6 +107,7 @@
   triforce_pool_min: 20
   triforce_pool_max: 40
   triforce_min_difference: 10
+  triforce_max_difference: 15
   dungeon_items:
     standard: 10
     mc: 3

--- a/mystery_testsuite.yml
+++ b/mystery_testsuite.yml
@@ -83,6 +83,7 @@ triforce_goal_max: 30
 triforce_pool_min: 30
 triforce_pool_max: 40
 triforce_min_difference: 10
+triforce_max_difference: 12
 map_shuffle:
   on: 1
   off: 1

--- a/resources/app/cli/args.json
+++ b/resources/app/cli/args.json
@@ -339,6 +339,7 @@
   "triforce_goal_min": {},
   "triforce_goal_max": {},
   "triforce_min_difference": {},
+  "triforce_max_difference": {},
   "custom": {
     "type": "bool",
     "help": "suppress"

--- a/source/classes/CustomSettings.py
+++ b/source/classes/CustomSettings.py
@@ -144,6 +144,11 @@ class CustomSettings(object):
                 args.pseudoboots[p] = get_setting(settings['pseudoboots'], args.pseudoboots[p])
                 args.triforce_goal[p] = get_setting(settings['triforce_goal'], args.triforce_goal[p])
                 args.triforce_pool[p] = get_setting(settings['triforce_pool'], args.triforce_pool[p])
+                args.triforce_goal_min[p] = get_setting(settings['triforce_goal_min'], args.triforce_goal_min[p])
+                args.triforce_goal_max[p] = get_setting(settings['triforce_goal_max'], args.triforce_goal_max[p])
+                args.triforce_pool_min[p] = get_setting(settings['triforce_pool_min'], args.triforce_pool_min[p])
+                args.triforce_pool_max[p] = get_setting(settings['triforce_pool_max'], args.triforce_pool_max[p])
+                args.triforce_min_difference[p] = get_setting(settings['triforce_min_difference'], args.triforce_min_difference[p])
                 args.beemizer[p] = get_setting(settings['beemizer'], args.beemizer[p])
 
                 # mystery usage

--- a/source/classes/CustomSettings.py
+++ b/source/classes/CustomSettings.py
@@ -149,6 +149,7 @@ class CustomSettings(object):
                 args.triforce_pool_min[p] = get_setting(settings['triforce_pool_min'], args.triforce_pool_min[p])
                 args.triforce_pool_max[p] = get_setting(settings['triforce_pool_max'], args.triforce_pool_max[p])
                 args.triforce_min_difference[p] = get_setting(settings['triforce_min_difference'], args.triforce_min_difference[p])
+                args.triforce_max_difference[p] = get_setting(settings['triforce_max_difference'], args.triforce_max_difference[p])
                 args.beemizer[p] = get_setting(settings['beemizer'], args.beemizer[p])
 
                 # mystery usage

--- a/source/tools/MysteryUtils.py
+++ b/source/tools/MysteryUtils.py
@@ -132,6 +132,7 @@ def roll_settings(weights):
     ret.triforce_goal_min = get_choice_default('triforce_goal_min', default=0)
     ret.triforce_goal_max = get_choice_default('triforce_goal_max', default=0)
     ret.triforce_min_difference = get_choice_default('triforce_min_difference', default=0)
+    ret.triforce_max_difference = get_choice_default('triforce_max_difference', default=10000)
 
     ret.mode = get_choice('world_state')
     if ret.mode == 'retro':

--- a/source/tools/MysteryUtils.py
+++ b/source/tools/MysteryUtils.py
@@ -125,15 +125,13 @@ def roll_settings(weights):
 
     ret.crystals_ganon = get_choice('ganon_open')
 
-    from ItemList import set_default_triforce
-    default_tf_goal, default_tf_pool = set_default_triforce(ret.goal, 0, 0)
-    goal_min = get_choice_default('triforce_goal_min', default=default_tf_goal)
-    goal_max = get_choice_default('triforce_goal_max', default=default_tf_goal)
-    pool_min = get_choice_default('triforce_pool_min', default=default_tf_pool)
-    pool_max = get_choice_default('triforce_pool_max', default=default_tf_pool)
-    ret.triforce_goal = random.randint(int(goal_min), int(goal_max))
-    min_diff = get_choice_default('triforce_min_difference', default=default_tf_pool-default_tf_goal)
-    ret.triforce_pool = random.randint(max(int(pool_min), ret.triforce_goal + int(min_diff)), int(pool_max))
+    ret.triforce_pool = get_choice_default('triforce_pool', default=0)
+    ret.triforce_goal = get_choice_default('triforce_goal', default=0)
+    ret.triforce_pool_min = get_choice_default('triforce_pool_min', default=0)
+    ret.triforce_pool_max = get_choice_default('triforce_pool_max', default=0)
+    ret.triforce_goal_min = get_choice_default('triforce_goal_min', default=0)
+    ret.triforce_goal_max = get_choice_default('triforce_goal_max', default=0)
+    ret.triforce_min_difference = get_choice_default('triforce_min_difference', default=0)
 
     ret.mode = get_choice('world_state')
     if ret.mode == 'retro':


### PR DESCRIPTION
Previously, to set the number of available and required Triforce Pieces, only triforce_goal and triforce_pool could be used in DungeonRandomizer.py and through Customizer YAMLs, and only triforce_goal_min, triforce_goal_max, triforce_pool_min, triforce_pool_max and triforce_min_difference could be used through Mystery YAMLs. With these changes, all of these can be used everywhere.
If none of the above values (besides triforce_min_difference) are changed from the default value of 0, the old behavior is used (the numbers are determined in ItemList.py from the Goal and possible Item Pool settings).
Otherwise, goal and total are set through triforce_goal and triforce_pool respectively if set, otherwise the corresponsing min and max values are used if both are set, or the default values depending on the Goal (8/10 for Trinity, 20/30 otherwise). When the total count is determined from an interval, the min and max values may be adjusted depending on the already determined goal count and the triforce_min_difference and triforce_max_difference values.
The triforce_max_difference setting is new because I felt it was missing and it may be very useful especially in races.
Exported Customizer YAMLs only contain the final piece counts, similar to how Random Intensity only prints the selected number.
Note that if a Mystery YAML is used and it doesn't specify a triforce_min_difference value, this value now defaults to 0 whereas it used to default to 10 previously.