### PR TITLE
Update ItemList.py

### DIFF
--- a/ItemList.py
+++ b/ItemList.py
@@ -1164,12 +1164,12 @@ def make_custom_item_pool(world, player, progressive, shuffle, difficulty, timer
         pool.extend(['Nothing'] * nothings)
 
     start_inventory = [x for x in world.precollected_items if x.player == player]
-    if world.logic[player] in ['owglitches', 'nologic'] and all(x !=' Pegasus Boots' for x in start_inventory):
+    if world.logic[player] in ['owglitches', 'nologic'] and all(x.name !=' Pegasus Boots' for x in start_inventory):
         precollected_items.append('Pegasus Boots')
         if 'Pegasus Boots' in pool:
             pool.remove('Pegasus Boots')
             pool.append('Rupees (20)')
-    if world.swords[player] == 'assured' and all(' Sword' not in x for x in start_inventory):
+    if world.swords[player] == 'assured' and all(' Sword' not in x.name for x in start_inventory):
         precollected_items.append('Progressive Sword')
         if 'Progressive Sword' in pool:
             pool.remove('Progressive Sword')


### PR DESCRIPTION
Fix iteration on item instead of name when using a custom pool in some cases.

Needed to add name for the iteration variable x in make_custom_item_pool. Without it the all(...) expressions fail since x is an item.
(First PR, if I missed something let me know 😄 )