### PR TITLE
Make placement of dungeon items faster

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -2277,7 +2277,7 @@ class Location(object):
         self.staleness_count = 0
         self.locked = False
         self.real = not crystal
-        self.always_allow = lambda item, state: False
+        self.always_allow = None
         self.access_rule = lambda state: True
         self.verbose_rule = None
         self.item_rule = lambda item: True
@@ -2291,7 +2291,7 @@ class Location(object):
     def can_fill(self, state, item, check_access=True):
         if not self.valid_multiworld(state, item):
             return False
-        return self.always_allow(state, item) or (self.parent_region.can_fill(item) and self.item_rule(item) and (not check_access or self.can_reach(state)))
+        return (self.always_allow and self.always_allow(state, item)) or (self.parent_region.can_fill(item) and self.item_rule(item) and (not check_access or self.can_reach(state)))
 
     def valid_multiworld(self, state, item):
         if self.type == LocationType.Pot and self.player != item.player:

--- a/Fill.py
+++ b/Fill.py
@@ -137,9 +137,13 @@ def fill_restrictive(world, base_state, locations, itempool, key_pool=None, sing
                 spot_to_fill = None
 
                 item_locations = filter_locations(item_to_place, locations, world, vanilla)
+                # for dungeon items, it is worth reducing this list further by excluding locations outside of the respective dungeon
+                reduced_locations = item_locations if not item_to_place.dungeon else \
+                                    [location for location in item_locations if not location.always_allow and location.parent_region.can_fill(item_to_place)]
+
                 verify(item_to_place, item_locations, maximum_exploration_state, single_player_placement,
                        perform_access_check, key_pool, world)
-                for location in item_locations:
+                for location in reduced_locations:
                     spot_to_fill = verify_spot_to_fill(location, item_to_place, maximum_exploration_state,
                                                        single_player_placement, perform_access_check, key_pool, world)
                     if spot_to_fill:


### PR DESCRIPTION
I noticed that placement of dungeon items was fairly slow. A lot of time was spent in `verify_spot_to_fill` for locations that could have already been ruled out as candidates for the current item because of a dungeon restriction, so this is what is implemented here.
Hopefully I did not miss any special cases where this change could introduce problems.
This change brings the average generation time for the default settings from 6.8 down to 3.2 seconds on my machine. For OWR, it would go from 19.2 to 6.4 seconds.