### PR TITLE
fix: money balancing bail and inverted Dark Sanctuary exit

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -1043,20 +1043,24 @@ def balance_money_progression(world):
                 else:
                     difference = 0
                     target_player = next(p for p in solvent)
+                def rupee_value(location):
+                    return rupee_chart[location.item.name] if location.item.name in rupee_chart else 0
                 while difference > 0:
                     swap_targets = [x for x in unchecked_locations if x not in sphere_locations and x.item.name.startswith('Rupees') and x.item.player == target_player]
-                    if len(swap_targets) == 0:
+                    best_swap = max(swap_targets, key=rupee_value) if swap_targets else None
+                    best_value = rupee_value(best_swap) if best_swap else 300
+                    increase_targets = [x for x in balance_locations[target_player] if rupee_value(x) < best_value]
+                    if len(increase_targets) == 0 and best_swap is not None:
+                        # every later rupee is worth no more than what the early spheres already hold; mint a 300 instead
                         best_swap, best_value = None, 300
-                    else:
-                        best_swap = max(swap_targets, key=lambda t: rupee_chart[t.item.name])
-                        best_value = rupee_chart[best_swap.item.name]
-                    increase_targets = [x for x in balance_locations[target_player] if x.item.name in rupee_chart and rupee_chart[x.item.name] < best_value]
+                        increase_targets = [x for x in balance_locations[target_player] if rupee_value(x) < best_value]
                     if len(increase_targets) == 0:
-                        increase_targets = [x for x in balance_locations[target_player] if (rupee_chart[x.item.name] if x.item.name in rupee_chart else 0) < best_value]
-                    if len(increase_targets) == 0:
-                        raise Exception('No early sphere swaps for rupees - money grind would be required - bailing for now')
-                    best_target = min(increase_targets, key=lambda t: rupee_chart[t.item.name] if t.item.name in rupee_chart else 0)
-                    old_value = rupee_chart[best_target.item.name] if best_target.item.name in rupee_chart else 0
+                        logger.warning(f'Player {target_player} is {difference:.0f} rupees short and no early location can hold more money - a money grind may be required')
+                        wallet[target_player] += difference
+                        difference = 0
+                        break
+                    best_target = min(increase_targets, key=rupee_value)
+                    old_value = rupee_value(best_target)
                     if best_swap is None:
                         logger.debug(f'Upgrading {best_target.item.name} @ {best_target.name} for 300 Rupees')
                         best_target.item = ItemFactory('Rupees (300)', best_target.item.player)

--- a/source/overworld/EntranceShuffle2.py
+++ b/source/overworld/EntranceShuffle2.py
@@ -168,6 +168,12 @@ def do_vanilla_connections(avail_pool):
             connect_vanilla_two_way(ent, avail_pool.default_map[ent], avail_pool)
         if ent in avail_pool.one_way_map and avail_pool.one_way_map[ent] in avail_pool.exits:
             connect_vanilla(ent, avail_pool.one_way_map[ent], avail_pool)
+    # inverted sanc
+    if avail_pool.inverted:
+        world, player = avail_pool.world, avail_pool.player
+        ext = world.get_entrance('Dark Sanctuary Hint Exit', player)
+        if ext.connected_region is None:
+            ext.connect(world.get_entrance('Dark Sanctuary Hint', player).parent_region)
 
 
 def do_main_shuffle(entrances, exits, avail, mode_def):

--- a/test/TestMoneyBalance.py
+++ b/test/TestMoneyBalance.py
@@ -1,0 +1,31 @@
+import unittest
+
+from CLI import parse_cli
+from Main import main
+from source.classes.BabelFish import BabelFish
+
+
+def generate(seed, *extra):
+    args = parse_cli(['--suppress_rom', '--spoiler', 'none', '--loglevel', 'warning', *extra])
+    main(args=args, seed=seed, fish=BabelFish(lang='en'))
+
+
+class TestMoneyBalance(unittest.TestCase):
+    def test_upgrade_when_later_rupees_are_too_small(self):
+        # seed 202: by the stall every early rupee spot already holds 20 or more and the only rupees left in
+        # later spheres are 5s and 20s, so no swap can add money; the pass must mint 300s instead of bailing
+        with self.assertLogs('', level='DEBUG') as logs:
+            generate(202)
+        messages = '\n'.join(logs.output)
+        self.assertIn('Upgrading Rupees', messages)
+        self.assertNotIn('money grind', messages)
+
+    def test_crossed_keysanity_seed(self):
+        with self.assertLogs('', level='DEBUG') as logs:
+            generate(1, '--shuffle', 'crossed', '--keyshuffle', 'wild', '--bigkeyshuffle', '--mapshuffle',
+                     '--compassshuffle', '--accessibility', 'locations')
+        self.assertNotIn('money grind', '\n'.join(logs.output))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Two fixes with tests.

**Money balancing.** `balance_money_progression` only minted a Rupees (300) when no rupee item remained in a later sphere. Once earlier swaps had lifted every early rupee spot to 20 or more and only 5s and 20s remained later, no swap could add money and it raised `No early sphere swaps for rupees - money grind would be required`. It now upgrades whenever no swap can add money, and only when every early location already holds 300 does it log a grind warning and continue. On 1000 crossed-entrance keysanity seeds with accessibility locations this took generation from 753 to 985 successes; the rupee failures went from 233 to 0.

**Inverted Dark Sanctuary.** With vanilla entrances in inverted mode `do_vanilla_connections` left the Dark Sanctuary Hint exit unconnected.

Testing: `pytest test/TestMoneyBalance.py` (seed 202 reproduces the stall, plus a crossed keysanity seed); inverted vanilla-entrance seeds generate.
