### PR TITLE
feat: static key logic and key door logic in the customizer

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -3139,7 +3139,7 @@ bow_mode = {'progressive': 0, 'silvers': 1, 'retro': 2, 'retro_silvers': 3}
 # byte 12: POOT TKKK (pseudoboots, overworld_map, trap_door_mode, key_logic_algo)
 overworld_map_mode = {'default': 0, 'compass': 1, 'map': 2}
 trap_door_mode = {'vanilla': 0, 'optional': 1, 'boss': 2, 'oneway': 3}
-key_logic_algo = {'dangerous': 0, 'partial': 1, 'strict': 2}
+key_logic_algo = {'dangerous': 0, 'partial': 1, 'strict': 2, 'static': 3}
 
 # byte 13: SSDD M??? (skullwoods, linked_drops, mirrorscroll, ??? = 3 free bytes)
 skullwoods_mode = {'original': 0, 'restricted': 1, 'loose': 2, 'followlinked': 3}

--- a/DoorShuffle.py
+++ b/DoorShuffle.py
@@ -21,6 +21,7 @@ from DungeonGenerator import dungeon_portals, dungeon_drops, connect_doors, coun
 from DungeonGenerator import valid_region_to_explore
 from KeyDoorShuffle import analyze_dungeon, build_key_layout, validate_key_layout, determine_prize_lock
 from KeyDoorShuffle import validate_bk_layout, DoorRules, apply_custom_key_rules
+from source.dungeon.StaticKeyLogic import static_door_rules
 from Utils import ncr, kth_combination
 
 
@@ -51,6 +52,8 @@ def link_doors(world, player):
             world.get_door("Skull Pinball WS", player).no_exit()
             world.swamp_patch_required[player] = orig_swamp_patch
             link_doors_prep(world, player)
+    if world.key_logic_algorithm[player] == 'static':
+        static_door_rules(world, player)
     apply_custom_key_rules(world, player)
 
 

--- a/DoorShuffle.py
+++ b/DoorShuffle.py
@@ -20,7 +20,7 @@ from DungeonGenerator import create_dungeon_builders, split_dungeon_builder, sim
 from DungeonGenerator import dungeon_portals, dungeon_drops, connect_doors, count_reserved_locations
 from DungeonGenerator import valid_region_to_explore
 from KeyDoorShuffle import analyze_dungeon, build_key_layout, validate_key_layout, determine_prize_lock
-from KeyDoorShuffle import validate_bk_layout, DoorRules
+from KeyDoorShuffle import validate_bk_layout, DoorRules, apply_custom_key_rules
 from Utils import ncr, kth_combination
 
 
@@ -51,6 +51,7 @@ def link_doors(world, player):
             world.get_door("Skull Pinball WS", player).no_exit()
             world.swamp_patch_required[player] = orig_swamp_patch
             link_doors_prep(world, player)
+    apply_custom_key_rules(world, player)
 
 
 def link_doors_prep(world, player):

--- a/KeyDoorShuffle.py
+++ b/KeyDoorShuffle.py
@@ -1410,13 +1410,20 @@ def apply_custom_key_rules(world, player):
         logger.warning('key_logic customization ignored for player %s: universal keys do not use door rules', player)
         return
     if world.key_logic_algorithm[player] == 'strict':
-        raise Exception('key_logic customization requires the partial or dangerous key logic algorithm')
+        raise Exception('key_logic customization requires the partial, dangerous or static key logic algorithm')
     chest_counting = custom['counting'] == 'chests'
+    if world.key_logic_algorithm[player] == 'static' and not chest_counting:
+        raise Exception('key_logic: the static algorithm counts chest keys, set counting: chests')
     if chest_counting and world.dropshuffle[player] != 'none':
         raise Exception('key_logic: counting chests requires unshuffled key drops')
+    apply_key_rule_specs(world, player, custom['doors'], chest_counting, validate=True)
+
+
+def apply_key_rule_specs(world, player, specs, chest_counting, validate):
+    logger = logging.getLogger('')
     layouts = world.key_layout[player]
     resolved, listed = {}, set()
-    for door_name, spec in custom['doors'].items():
+    for door_name, spec in specs.items():
         door = world.get_door(door_name, player)
         dungeon = next((name for name, layout in layouts.items() if door in layout.flat_prop), None)
         if dungeon is None:
@@ -1435,13 +1442,15 @@ def apply_custom_key_rules(world, player):
             key_logic.chest_counting = True
             missing = [d.name for d in layouts[dungeon].flat_prop
                        if d not in resolved and KeyRuleType.WorstCase in key_logic.door_rules.get(d.name, DoorRules(0, True)).new_rules]
-            if missing:
+            if missing and validate:
                 raise Exception(f'key_logic: counting chests needs every key door of {dungeon} listed, missing {missing}')
     for door, (dungeon, spec) in resolved.items():
         layout = layouts[dungeon]
         key_logic = layout.key_logic
         number = spec['keys']
-        if chest_counting:
+        if not validate:
+            floor, ceiling = None, None
+        elif chest_counting:
             floor, ceiling = None, layout.max_chests
         else:
             floor = min((ctr.used_keys + 1 for ctr in layout.key_counters.values() if door in ctr.child_doors),
@@ -1454,7 +1463,7 @@ def apply_custom_key_rules(world, player):
             # unlisted pair side keeps its own floor
             logger.debug('key_logic: %s raised from %s to its minimum of %s keys', door.name, number, floor)
             number = floor
-        if number > ceiling:
+        if ceiling is not None and number > ceiling:
             raise Exception(f'key_logic: {door.name} cannot require {number} keys, {dungeon} only has {ceiling}')
         rule = key_logic.door_rules.get(door.name)
         if rule is None:
@@ -1463,7 +1472,7 @@ def apply_custom_key_rules(world, player):
             if door.dest and door.dest.name in key_logic.door_rules:
                 rule.opposite = key_logic.door_rules[door.dest.name]
                 rule.opposite.opposite = rule
-        elif not chest_counting:
+        elif validate and not chest_counting:
             current = min(rule.new_rules.get(KeyRuleType.WorstCase, rule.small_key_num), rule.small_key_num)
             if number < current:
                 logger.warning('key_logic: %s lowered from %s to %s keys, the analysis considered that a risk',

--- a/KeyDoorShuffle.py
+++ b/KeyDoorShuffle.py
@@ -63,6 +63,7 @@ class KeyLogic(object):
         self.dungeon = dungeon_name
         self.sm_doors = {}
         self.prize_location = None
+        self.chest_counting = False  # door numbers count chest keys only, drops excluded
 
     def check_placement(self, unplaced_keys, wild_keys, reached_keys, self_locking_keys,
                         big_key_loc=None, prize_loc=None, cr_count=7):
@@ -1398,6 +1399,96 @@ def set_paired_rules(key_logic, world, player):
         door = world.get_door(d_name, player)
         if door.dest.name in key_logic.door_rules.keys():
             rule.opposite = key_logic.door_rules[door.dest.name]
+
+
+def apply_custom_key_rules(world, player):
+    custom = world.customizer.get_key_logic(player) if world.customizer else None
+    if not custom or not custom['doors']:
+        return
+    logger = logging.getLogger('')
+    if world.keyshuffle[player] == 'universal':
+        logger.warning('key_logic customization ignored for player %s: universal keys do not use door rules', player)
+        return
+    if world.key_logic_algorithm[player] == 'strict':
+        raise Exception('key_logic customization requires the partial or dangerous key logic algorithm')
+    chest_counting = custom['counting'] == 'chests'
+    if chest_counting and world.dropshuffle[player] != 'none':
+        raise Exception('key_logic: counting chests requires unshuffled key drops')
+    layouts = world.key_layout[player]
+    resolved, listed = {}, set()
+    for door_name, spec in custom['doors'].items():
+        door = world.get_door(door_name, player)
+        dungeon = next((name for name, layout in layouts.items() if door in layout.flat_prop), None)
+        if dungeon is None:
+            raise Exception(f'key_logic: {door_name} is not a small key door in this layout. '
+                            f'List it under doors with "type: Key Door" to make it one')
+        resolved[door] = (dungeon, spec)
+        listed.add(door)
+    for door, (dungeon, spec) in list(resolved.items()):
+        partner = layouts[dungeon].key_logic.sm_doors.get(door)
+        if partner and partner not in resolved:
+            resolved[partner] = (dungeon, {'keys': spec['keys']})
+    if chest_counting:
+        # analyzed numbers count drops, so a dungeon is either all preset or untouched
+        for dungeon in {d for d, _ in resolved.values()}:
+            key_logic = layouts[dungeon].key_logic
+            key_logic.chest_counting = True
+            missing = [d.name for d in layouts[dungeon].flat_prop
+                       if d not in resolved and KeyRuleType.WorstCase in key_logic.door_rules.get(d.name, DoorRules(0, True)).new_rules]
+            if missing:
+                raise Exception(f'key_logic: counting chests needs every key door of {dungeon} listed, missing {missing}')
+    for door, (dungeon, spec) in resolved.items():
+        layout = layouts[dungeon]
+        key_logic = layout.key_logic
+        number = spec['keys']
+        if chest_counting:
+            floor, ceiling = None, layout.max_chests
+        else:
+            floor = min((ctr.used_keys + 1 for ctr in layout.key_counters.values() if door in ctr.child_doors),
+                        default=None)
+            ceiling = layout.max_chests + layout.max_drops
+        if floor is not None and number < floor:
+            if door in listed:
+                raise Exception(f'key_logic: {door.name} cannot require fewer than {floor} keys, '
+                                f'no route reaches it having used fewer than {floor - 1}')
+            # unlisted pair side keeps its own floor
+            logger.debug('key_logic: %s raised from %s to its minimum of %s keys', door.name, number, floor)
+            number = floor
+        if number > ceiling:
+            raise Exception(f'key_logic: {door.name} cannot require {number} keys, {dungeon} only has {ceiling}')
+        rule = key_logic.door_rules.get(door.name)
+        if rule is None:
+            rule = DoorRules(number, True)
+            key_logic.door_rules[door.name] = rule
+            if door.dest and door.dest.name in key_logic.door_rules:
+                rule.opposite = key_logic.door_rules[door.dest.name]
+                rule.opposite.opposite = rule
+        elif not chest_counting:
+            current = min(rule.new_rules.get(KeyRuleType.WorstCase, rule.small_key_num), rule.small_key_num)
+            if number < current:
+                logger.warning('key_logic: %s lowered from %s to %s keys, the analysis considered that a risk',
+                               door.name, current, number)
+        rule.small_key_num = number
+        rule.new_rules[KeyRuleType.WorstCase] = number
+        if 'big_key_in' in spec:
+            rule.alternate_big_key_loc = {world.get_location(name, player) for name in spec['big_key_in']}
+            rule.new_rules[(KeyRuleType.Lock, key_logic.bk_name)] = spec['with_big_key']
+            rule.alternate_small_key = spec['with_big_key']
+        if 'small_key_in' in spec:
+            rule.small_location = world.get_location(spec['small_key_in'], player)
+            rule.allow_small = True
+            rule.new_rules[KeyRuleType.AllowSmall] = spec['with_small_key']
+        # remaining alternatives stay one below the new number
+        for rule_type in list(rule.new_rules.keys()):
+            if rule_type == KeyRuleType.WorstCase:
+                continue
+            if number == 0:
+                del rule.new_rules[rule_type]
+            elif rule.new_rules[rule_type] >= number:
+                rule.new_rules[rule_type] = number - 1
+        if rule.alternate_small_key is not None and rule.alternate_small_key >= number:
+            rule.alternate_small_key = max(number - 1, 0)
+        logger.debug('key_logic: %s (%s) set to %s keys', door.name, dungeon, number)
 
 
 def check_bk_special(regions, world, player):

--- a/Main.py
+++ b/Main.py
@@ -98,77 +98,7 @@ def main(args, seed=None, fish=None):
     if args.securerandom:
         world.seed = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(9))
 
-    world.boots_hint = args.boots_hint.copy()
-    world.remote_items = args.remote_items.copy()
-    world.mapshuffle = args.mapshuffle.copy()
-    world.compassshuffle = args.compassshuffle.copy()
-    world.keyshuffle = args.keyshuffle.copy()
-    world.bigkeyshuffle = args.bigkeyshuffle.copy()
-    world.bombbag = args.bombbag.copy()
-    world.flute_mode = args.flute_mode.copy()
-    world.bow_mode = args.bow_mode.copy()
-    world.crystals_needed_for_ganon = {player: random.randint(0, 7) if args.crystals_ganon[player] == 'random' else int(args.crystals_ganon[player]) for player in range(1, world.players + 1)}
-    world.crystals_needed_for_gt = {player: random.randint(0, 7) if args.crystals_gt[player] == 'random' else int(args.crystals_gt[player]) for player in range(1, world.players + 1)}
-    world.crystals_ganon_orig = args.crystals_ganon.copy()
-    world.crystals_gt_orig = args.crystals_gt.copy()
-    world.open_pyramid = args.openpyramid.copy()
-    world.boss_shuffle = args.shufflebosses.copy()
-    world.enemy_shuffle = args.shuffleenemies.copy()
-    world.enemy_health = args.enemy_health.copy()
-    world.enemy_damage = args.enemy_damage.copy()
-    world.any_enemy_logic = args.any_enemy_logic.copy()
-    world.beemizer = {player: str(args.beemizer[player]) for player in range(1, world.players + 1)}
-    world.intensity = {player: random.randint(1, 3) if args.intensity[player] == 'random' else int(args.intensity[player]) for player in range(1, world.players + 1)}
-    world.door_type_mode = args.door_type_mode.copy()
-    world.trap_door_mode = args.trap_door_mode.copy()
-    world.key_logic_algorithm = args.key_logic_algorithm.copy()
-    world.decoupledoors = args.decoupledoors.copy()
-    world.door_self_loops = args.door_self_loops.copy()
-    world.experimental = args.experimental.copy()
-    world.dungeon_counters = args.dungeon_counters.copy()
-    world.fish = fish
-    world.shopsanity = args.shopsanity.copy()
-    world.dropshuffle = args.dropshuffle.copy()
-    world.pottery = args.pottery.copy()
-    world.potshuffle = args.shufflepots.copy()
-    world.mixed_travel = args.mixed_travel.copy()
-    world.standardize_palettes = args.standardize_palettes.copy()
-    world.shufflelinks = args.shufflelinks.copy()
-    world.shuffletavern = args.shuffletavern.copy()
-    world.skullwoods = args.skullwoods.copy()
-    world.linked_drops = args.linked_drops.copy()
-    world.pseudoboots = args.pseudoboots.copy()
-    world.mirrorscroll = args.mirrorscroll.copy()
-    world.overworld_map = args.overworld_map.copy()
-    world.take_any = args.take_any.copy()
-    world.restrict_boss_items = args.restrict_boss_items.copy()
-    world.collection_rate = args.collection_rate.copy()
-    world.colorizepots = args.colorizepots.copy()
-    world.aga_randomness = args.aga_randomness.copy()
-    world.money_balance = args.money_balance.copy()
-
-    world.treasure_hunt_count = {}
-    world.treasure_hunt_total = {}
-    for p in args.triforce_goal:
-        if int(args.triforce_goal[p]) != 0 or int(args.triforce_pool[p]) != 0 or int(args.triforce_goal_min[p]) != 0 or int(args.triforce_goal_max[p]) != 0 or int(args.triforce_pool_min[p]) != 0 or int(args.triforce_pool_max[p]) != 0:
-            if int(args.triforce_goal[p]) != 0:
-                world.treasure_hunt_count[p] = int(args.triforce_goal[p])
-            elif int(args.triforce_goal_min[p]) != 0 and int(args.triforce_goal_max[p]) != 0:
-                world.treasure_hunt_count[p] = random.randint(int(args.triforce_goal_min[p]), int(args.triforce_goal_max[p]))
-            else:
-                world.treasure_hunt_count[p] = 8 if world.goal[p] == 'trinity' else 20
-            if int(args.triforce_pool[p]) != 0:
-                world.treasure_hunt_total[p] = int(args.triforce_pool[p])
-            elif int(args.triforce_pool_min[p]) != 0 and int(args.triforce_pool_max[p]) != 0:
-                world.treasure_hunt_total[p] = random.randint(max(int(args.triforce_pool_min[p]), world.treasure_hunt_count[p] + int(args.triforce_min_difference[p])), min(int(args.triforce_pool_max[p]), world.treasure_hunt_count[p] + int(args.triforce_max_difference[p])))
-            else:
-                world.treasure_hunt_total[p] = 10 if world.goal[p] == 'trinity' else 30
-        else:
-            # this will be handled in ItemList.py and custom item pool is used to determine the numbers
-            world.treasure_hunt_count[p], world.treasure_hunt_total[p] = 0, 0
-
-    world.rom_seeds = {player: random.randint(0, 999999999) for player in range(1, world.players + 1)}
-    world.finish_init()
+    set_world_options(world, args, fish)
 
     # custom settings - these haven't been promoted to full settings yet
     in_progress_settings = ['force_enemy', 'free_lamp_cone']
@@ -467,6 +397,80 @@ def main(args, seed=None, fish=None):
 #    print_wiki_doors_by_region(dungeon_regions,world,1)
 
     return world
+
+
+def set_world_options(world, args, fish):
+    world.boots_hint = args.boots_hint.copy()
+    world.remote_items = args.remote_items.copy()
+    world.mapshuffle = args.mapshuffle.copy()
+    world.compassshuffle = args.compassshuffle.copy()
+    world.keyshuffle = args.keyshuffle.copy()
+    world.bigkeyshuffle = args.bigkeyshuffle.copy()
+    world.bombbag = args.bombbag.copy()
+    world.flute_mode = args.flute_mode.copy()
+    world.bow_mode = args.bow_mode.copy()
+    world.crystals_needed_for_ganon = {player: random.randint(0, 7) if args.crystals_ganon[player] == 'random' else int(args.crystals_ganon[player]) for player in range(1, world.players + 1)}
+    world.crystals_needed_for_gt = {player: random.randint(0, 7) if args.crystals_gt[player] == 'random' else int(args.crystals_gt[player]) for player in range(1, world.players + 1)}
+    world.crystals_ganon_orig = args.crystals_ganon.copy()
+    world.crystals_gt_orig = args.crystals_gt.copy()
+    world.open_pyramid = args.openpyramid.copy()
+    world.boss_shuffle = args.shufflebosses.copy()
+    world.enemy_shuffle = args.shuffleenemies.copy()
+    world.enemy_health = args.enemy_health.copy()
+    world.enemy_damage = args.enemy_damage.copy()
+    world.any_enemy_logic = args.any_enemy_logic.copy()
+    world.beemizer = {player: str(args.beemizer[player]) for player in range(1, world.players + 1)}
+    world.intensity = {player: random.randint(1, 3) if args.intensity[player] == 'random' else int(args.intensity[player]) for player in range(1, world.players + 1)}
+    world.door_type_mode = args.door_type_mode.copy()
+    world.trap_door_mode = args.trap_door_mode.copy()
+    world.key_logic_algorithm = args.key_logic_algorithm.copy()
+    world.decoupledoors = args.decoupledoors.copy()
+    world.door_self_loops = args.door_self_loops.copy()
+    world.experimental = args.experimental.copy()
+    world.dungeon_counters = args.dungeon_counters.copy()
+    world.fish = fish
+    world.shopsanity = args.shopsanity.copy()
+    world.dropshuffle = args.dropshuffle.copy()
+    world.pottery = args.pottery.copy()
+    world.potshuffle = args.shufflepots.copy()
+    world.mixed_travel = args.mixed_travel.copy()
+    world.standardize_palettes = args.standardize_palettes.copy()
+    world.shufflelinks = args.shufflelinks.copy()
+    world.shuffletavern = args.shuffletavern.copy()
+    world.skullwoods = args.skullwoods.copy()
+    world.linked_drops = args.linked_drops.copy()
+    world.pseudoboots = args.pseudoboots.copy()
+    world.mirrorscroll = args.mirrorscroll.copy()
+    world.overworld_map = args.overworld_map.copy()
+    world.take_any = args.take_any.copy()
+    world.restrict_boss_items = args.restrict_boss_items.copy()
+    world.collection_rate = args.collection_rate.copy()
+    world.colorizepots = args.colorizepots.copy()
+    world.aga_randomness = args.aga_randomness.copy()
+    world.money_balance = args.money_balance.copy()
+
+    world.treasure_hunt_count = {}
+    world.treasure_hunt_total = {}
+    for p in args.triforce_goal:
+        if int(args.triforce_goal[p]) != 0 or int(args.triforce_pool[p]) != 0 or int(args.triforce_goal_min[p]) != 0 or int(args.triforce_goal_max[p]) != 0 or int(args.triforce_pool_min[p]) != 0 or int(args.triforce_pool_max[p]) != 0:
+            if int(args.triforce_goal[p]) != 0:
+                world.treasure_hunt_count[p] = int(args.triforce_goal[p])
+            elif int(args.triforce_goal_min[p]) != 0 and int(args.triforce_goal_max[p]) != 0:
+                world.treasure_hunt_count[p] = random.randint(int(args.triforce_goal_min[p]), int(args.triforce_goal_max[p]))
+            else:
+                world.treasure_hunt_count[p] = 8 if world.goal[p] == 'trinity' else 20
+            if int(args.triforce_pool[p]) != 0:
+                world.treasure_hunt_total[p] = int(args.triforce_pool[p])
+            elif int(args.triforce_pool_min[p]) != 0 and int(args.triforce_pool_max[p]) != 0:
+                world.treasure_hunt_total[p] = random.randint(max(int(args.triforce_pool_min[p]), world.treasure_hunt_count[p] + int(args.triforce_min_difference[p])), min(int(args.triforce_pool_max[p]), world.treasure_hunt_count[p] + int(args.triforce_max_difference[p])))
+            else:
+                world.treasure_hunt_total[p] = 10 if world.goal[p] == 'trinity' else 30
+        else:
+            # this will be handled in ItemList.py and custom item pool is used to determine the numbers
+            world.treasure_hunt_count[p], world.treasure_hunt_total[p] = 0, 0
+
+    world.rom_seeds = {player: random.randint(0, 999999999) for player in range(1, world.players + 1)}
+    world.finish_init()
 
 
 def copy_world(world):

--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ Determines how small key door logic works.
 * Partial Protection: Assumes you always have full inventory and worse case usage. This should account for dark room and bunny revival glitches.
 * Strict: For those would like to glitch and be protected from yourselves. Small keys door require all small keys to be available to be in logic.
 * Dangerous: Assumes you never use keys out of logic. This is the most dangerous setting and not recommend for use.
+* Static: The entrance randomizer's hand-written key rules, counting chest keys only. Requires vanilla doors and unshuffled key drops and key pots; entrance shuffle is fine.
 
-CLI: `--key_logic [partial|strict|dangerous]`
+CLI: `--key_logic [partial|strict|dangerous|static]`
 
 ### Decouple Doors
 

--- a/Rules.py
+++ b/Rules.py
@@ -2387,23 +2387,24 @@ def eval_small_key_door_main(state, door_name, dungeon, player):
     if door_name not in key_logic.door_rules:
         return False
     door_rule = key_logic.door_rules[door_name]
+    has_keys = state.has_sm_key_strict if key_logic.chest_counting else state.has_sm_key
     door_openable = False
     for ruleType, number in door_rule.new_rules.items():
         if door_openable:
             return True
         if ruleType == KeyRuleType.WorstCase:
-            door_openable |= state.has_sm_key(key_logic.small_key_name, player, number)
+            door_openable |= has_keys(key_logic.small_key_name, player, number)
         elif ruleType == KeyRuleType.AllowSmall:
             small_loc_item = door_rule.small_location.item
             if small_loc_item and small_loc_item.name == key_logic.small_key_name and small_loc_item.player == player:
-                door_openable |= state.has_sm_key(key_logic.small_key_name, player, number)
+                door_openable |= has_keys(key_logic.small_key_name, player, number)
         elif isinstance(ruleType, tuple):
             lock, lock_item = ruleType
             # this doesn't track logical locks yet, i.e. hammer locks the item and hammer is there, but the item isn't
             for loc in door_rule.alternate_big_key_loc:
                 spot = state.world.get_location(loc, player)
                 if spot.item and spot.item.name == lock_item:
-                    door_openable |= state.has_sm_key(key_logic.small_key_name, player, number)
+                    door_openable |= has_keys(key_logic.small_key_name, player, number)
                     break
     return door_openable
 
@@ -2415,17 +2416,18 @@ def eval_small_key_door_partial_main(state, door_name, dungeon, player):
     if door_name not in key_logic.door_rules:
         return False
     door_rule = key_logic.door_rules[door_name]
+    has_keys = state.has_sm_key_strict if key_logic.chest_counting else state.has_sm_key
     door_openable = False
     for ruleType, number in door_rule.new_rules.items():
         if door_openable:
             return True
         if ruleType == KeyRuleType.WorstCase:
             number = min(number, door_rule.small_key_num)
-            door_openable |= state.has_sm_key(key_logic.small_key_name, player, number)
+            door_openable |= has_keys(key_logic.small_key_name, player, number)
         elif ruleType == KeyRuleType.AllowSmall:
             small_loc_item = door_rule.small_location.item
             if small_loc_item and small_loc_item.name == key_logic.small_key_name and small_loc_item.player == player:
-                door_openable |= state.has_sm_key(key_logic.small_key_name, player, number)
+                door_openable |= has_keys(key_logic.small_key_name, player, number)
         elif isinstance(ruleType, tuple):
             lock, lock_item = ruleType
             # this doesn't track logical locks yet, i.e. hammer locks the item and hammer is there, but the item isn't
@@ -2433,11 +2435,11 @@ def eval_small_key_door_partial_main(state, door_name, dungeon, player):
                 spot = state.world.get_location(loc, player)
                 if spot.item and spot.item.name == lock_item:
                     number = min(number, door_rule.alternate_small_key)
-                    door_openable |= state.has_sm_key(key_logic.small_key_name, player, number)
+                    door_openable |= has_keys(key_logic.small_key_name, player, number)
                     break
             if state.placing_items and any(lock_item == item.name for item in state.placing_items):
                 number = min(number, door_rule.alternate_small_key)
-                door_openable |= state.has_sm_key(key_logic.small_key_name, player, number)
+                door_openable |= has_keys(key_logic.small_key_name, player, number)
     return door_openable
 
 

--- a/Rules.py
+++ b/Rules.py
@@ -53,6 +53,9 @@ def set_rules(world, player):
         standard_rules(world, player)
     else:
         misc_key_rules(world, player)
+    if world.key_logic_algorithm[player] == 'static':
+        from source.dungeon.StaticKeyLogic import set_static_key_rules
+        set_static_key_rules(world, player)
 
     bomb_rules(world, player)
     pot_rules(world, player)

--- a/docs/Customizer.md
+++ b/docs/Customizer.md
@@ -150,7 +150,7 @@ Chris Houlihan and Links House should be specified together or not at all.
 
 ### doors
 
-This must be defined by player. Each player number should be listed with the appropriate sections. This section has three primary subsections: `lobbies` and `doors`.
+This must be defined by player. Each player number should be listed with the appropriate sections. This section has three primary subsections: `lobbies`, `doors` and `key_logic`.
 
 `lobbies` lists the doors by which each dungeon is entered
 
@@ -180,6 +180,30 @@ You'll note that sub-tile door do not need to be listed, but if you want them to
  ##### Known Issue
  
  If you specify a door type and those doors cannot be a stateful door due to the nature of the supertile (or you've placed too many on the supertile) an exception is thrown. 
+
+`key_logic` overrides the number of small keys the logic requires to open a small key door. Normally the key logic analysis computes this number; this section lets a preset set it, for example to test a key logic scenario.
+
+```
+key_logic:
+  counting: chests
+  doors:
+    GT Tile Room EN: 3
+    GT Hookshot ES:
+      keys: 4
+      big_key_in: Ganons Tower - Map Chest
+      with_big_key: 3
+      small_key_in: Ganons Tower - Map Chest
+      with_small_key: 3
+    Hyrule Dungeon Map Room Key Door S: 1
+```
+
+`counting` is `all` (default), where a number is the total keys of that dungeon the player must hold, drop keys included, or `chests`, where only chest keys count and drops are ignored. `chests` matches the entrance randomizer's key rules and needs unshuffled key drops; 0 then means the drops on the way cover the door.
+
+`doors` maps a door name, as used in the `doors` section, to a number or to a mapping with `keys` and optional conditionals: `big_key_in` names one chest or a list of chests, and `with_big_key` is the number that applies while the big key sits in one of them (default one fewer than `keys`); `small_key_in` and `with_small_key` do the same for a small key behind the door. A plain number keeps the conditionals the analysis found for that door, lowered to one below the new number.
+
+The door must be a small key door in the final layout (list it under `doors` with `type: Key Door` to force one). Either side of a paired door may be named; the other side gets the same number, without conditionals, unless it is listed on its own.
+
+With `counting: all` the number must be at least the fewest keys any route could have used before reaching the door plus one, and at most the dungeon's total key count; an unlisted pair side below its own minimum takes that minimum. With `counting: chests` the ceiling is the dungeon's chest key count. Anything outside the range throws an exception. The section only affects the `partial` and `dangerous` key logic algorithms. It is ignored with universal keys and throws with `strict`, which never reads door rules. Key placement rules are not changed, so a preset that the placement validator considers a keylock still fails generation. When a generated seed is exported as a customizer file, this section is filled in with the numbers the logic used, one entry per door side, without conditionals.
 
 ### medallions
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files = Test*.py test_*.py
+testpaths = test

--- a/resources/app/cli/args.json
+++ b/resources/app/cli/args.json
@@ -210,7 +210,8 @@
     "choices": [
       "dangerous",
       "partial",
-      "strict"
+      "strict",
+      "static"
     ]
   },
   "decoupledoors": {

--- a/resources/app/cli/lang/en.json
+++ b/resources/app/cli/lang/en.json
@@ -263,7 +263,8 @@
       "Key Logic Algorithm (default: %(default)s)",
       "dangerous: Key usage must follow logic for safety",
       "partial: Partial protection when using certain minor glitches",
-      "strict:  Ensure small keys are available"
+      "strict:  Ensure small keys are available",
+      "static:  Entrance randomizer key rules; vanilla doors and key drops only"
     ],
     "decoupledoors" : [ "Door entrances and exits are decoupled" ],
     "door_self_loops" : [ "Spiral stairs are allowed to self-loop" ],

--- a/resources/app/gui/lang/en.json
+++ b/resources/app/gui/lang/en.json
@@ -89,6 +89,7 @@
     "randomizer.dungeon.key_logic_algorithm.dangerous": "Dangerous",
     "randomizer.dungeon.key_logic_algorithm.partial": "Partial Protection",
     "randomizer.dungeon.key_logic_algorithm.strict": "Strict",
+    "randomizer.dungeon.key_logic_algorithm.static": "Static (Entrance Randomizer)",
 
     "randomizer.dungeon.experimental": "Enable Experimental Features",
 

--- a/resources/app/gui/randomize/dungeon/widgets.json
+++ b/resources/app/gui/randomize/dungeon/widgets.json
@@ -6,7 +6,8 @@
       "options": [
         "partial",
         "strict",
-        "dangerous"
+        "dangerous",
+        "static"
       ],
       "config": {
         "padx": [20,0],

--- a/source/classes/CustomSettings.py
+++ b/source/classes/CustomSettings.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import RaceRandom as random
-from BaseClasses import LocationType, DoorType
+from BaseClasses import LocationType, DoorType, KeyRuleType
 from source.tools.MysteryUtils import roll_settings, get_weights
 
 
@@ -229,6 +229,49 @@ class CustomSettings(object):
         if 'doors' in self.file_source:
             return self.file_source['doors']
         return None
+
+    def get_key_logic(self, player):
+        doors = self.get_doors()
+        if not doors or player not in doors or not doors[player] or 'key_logic' not in doors[player]:
+            return None
+        section = doors[player]['key_logic'] or {}
+        counting = section.get('counting', 'all')
+        if counting not in ('all', 'chests'):
+            raise Exception(f'key_logic: counting must be "all" or "chests", found {counting!r}')
+        if 'doors' not in section:
+            raise Exception('key_logic: expected a "doors" mapping of door names to key numbers')
+        result = {'counting': counting, 'doors': {}}
+        for door_name, spec in (section['doors'] or {}).items():
+            result['doors'][door_name] = self.parse_key_rule(door_name, spec)
+        return result
+
+    @staticmethod
+    def parse_key_rule(door_name, spec):
+        def number(key, value):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise Exception(f'key_logic: {door_name} {key} must be a non-negative integer, found {value!r}')
+            return value
+        if not isinstance(spec, dict):
+            return {'keys': number('keys', spec)}
+        allowed = {'keys', 'big_key_in', 'with_big_key', 'small_key_in', 'with_small_key'}
+        unknown = set(spec) - allowed
+        if unknown or 'keys' not in spec:
+            raise Exception(f'key_logic: {door_name} takes keys, big_key_in, with_big_key, small_key_in, with_small_key')
+        rule = {'keys': number('keys', spec['keys'])}
+        for key, needs in (('with_big_key', 'big_key_in'), ('with_small_key', 'small_key_in')):
+            if key in spec and needs not in spec:
+                raise Exception(f'key_logic: {door_name} {key} needs {needs}')
+        if 'big_key_in' in spec:
+            locs = spec['big_key_in']
+            rule['big_key_in'] = [locs] if isinstance(locs, str) else list(locs)
+            rule['with_big_key'] = number('with_big_key', spec.get('with_big_key', max(rule['keys'] - 1, 0)))
+        if 'small_key_in' in spec:
+            rule['small_key_in'] = spec['small_key_in']
+            rule['with_small_key'] = number('with_small_key', spec.get('with_small_key', max(rule['keys'] - 1, 0)))
+        for key in ('with_big_key', 'with_small_key'):
+            if key in rule and rule[key] > rule['keys']:
+                raise Exception(f'key_logic: {door_name} {key} cannot exceed keys')
+        return rule
 
     def get_bosses(self):
         if 'bosses' in self.file_source:
@@ -455,6 +498,14 @@ class CustomSettings(object):
                         else:
                             door_value = {'dest': door.dest.name, 'one-way': True}
                         door_map[door.name] = door_value
+            key_rules, chest_counting = {}, False
+            for key_logic in world.key_logic.get(p, {}).values():
+                chest_counting |= key_logic.chest_counting
+                for door_name, rule in key_logic.door_rules.items():
+                    if KeyRuleType.WorstCase in rule.new_rules:
+                        key_rules[door_name] = min(rule.small_key_num, rule.new_rules[KeyRuleType.WorstCase])
+            if key_rules:
+                meta_doors['key_logic'] = {'counting': 'chests' if chest_counting else 'all', 'doors': key_rules}
 
     def record_medallions(self):
         pass

--- a/source/dungeon/StaticKeyLogic.py
+++ b/source/dungeon/StaticKeyLogic.py
@@ -1,0 +1,236 @@
+# Entrance randomizer key logic for vanilla dungeons: key_logic_algorithm 'static'.
+# Numbers count chest keys only, as the entrance randomizer's has_key does.
+from BaseClasses import KeyRuleType
+from Dungeons import dungeon_keys, dungeon_bigs
+from KeyDoorShuffle import apply_key_rule_specs
+
+GT_RANDOMIZER = ['Ganons Tower - Randomizer Room - Top Left', 'Ganons Tower - Randomizer Room - Top Right',
+                 'Ganons Tower - Randomizer Room - Bottom Left', 'Ganons Tower - Randomizer Room - Bottom Right']
+GT_COMPASS = ['Ganons Tower - Compass Room - Top Left', 'Ganons Tower - Compass Room - Top Right',
+              'Ganons Tower - Compass Room - Bottom Left', 'Ganons Tower - Compass Room - Bottom Right']
+TR_EYE_BRIDGE = ['Turtle Rock - Eye Bridge - Bottom Left', 'Turtle Rock - Eye Bridge - Bottom Right',
+                 'Turtle Rock - Eye Bridge - Top Left', 'Turtle Rock - Eye Bridge - Top Right']
+
+DOOR_RULES = {
+    'Hyrule Castle': {
+        'Sewers Secret Room Key Door S': 1, 'Sewers Key Rat NE': 1,
+        'Sewers Dark Cross Key Door N': 0, 'Hyrule Dungeon Map Room Key Door S': 0,
+        'Hyrule Dungeon Armory Interior Key Door N': 0,
+    },
+    'Eastern Palace': {'Eastern Dark Square Key Door WN': 0, 'Eastern Darkness Up Stairs': 0},
+    'Desert Palace': {
+        'Desert East Wing Key Door EN': 1, 'Desert Tiles 1 Up Stairs': 0, 'Desert Beamos Hall NE': 0,
+        'Desert Tiles 2 NE': 0,
+    },
+    'Tower of Hera': {
+        'Hera Lobby Key Stairs': {'keys': 1, 'small_key_in': 'Tower of Hera - Big Key Chest', 'with_small_key': 0},
+    },
+    'Agahnims Tower': {
+        'Tower Room 03 Up Stairs': 1, 'Tower Dark Maze ES': 2, 'Tower Dark Archers Up Stairs': 2,
+        'Tower Circle of Pots ES': 2,
+    },
+    'Palace of Darkness': {
+        'PoD Middle Cage N': 1, 'PoD Arena Main NW': 4, 'PoD Falling Bridge WN': 6,
+        'PoD Basement Ledge Up Stairs': {'keys': 6, 'small_key_in': 'Palace of Darkness - Big Key Chest',
+                                         'with_small_key': 3},
+        'PoD Compass Room SE': {'keys': 6, 'small_key_in': 'Palace of Darkness - Harmless Hellway',
+                                'with_small_key': 4},
+        'PoD Dark Pegs WN': 6,
+    },
+    'Swamp Palace': {
+        'Swamp Entrance Down Stairs': 1, 'Swamp Pot Row WS': 0, 'Swamp Trench 1 Key Ledge NW': 0,
+        'Swamp Hub WN': 0, 'Swamp Hub North Ledge N': 0, 'Swamp Waterway NW': 0,
+    },
+    'Skull Woods': {
+        'Skull Map Room SE': 1, 'Skull Pinball NE': 1, 'Skull 1 Lobby WS': 2, 'Skull 2 West Lobby NW': 0,
+        'Skull 3 Lobby NW': 3, 'Skull Spike Corner ES': 3,
+    },
+    'Thieves Town': {
+        'Thieves Hallway WS': 0, 'Thieves Spike Switch Up Stairs': 1,
+        'Thieves Conveyor Bridge WS': {'keys': 1, 'small_key_in': "Thieves' Town - Big Chest", 'with_small_key': 0},
+    },
+    'Ice Palace': {
+        'Ice Jelly Key Down Stairs': 0, 'Ice Conveyor SW': 0,
+        # without hookshot the east side is only in logic with the big key over there; 3 keys never exist
+        'Ice Spike Cross ES': {'keys': 3, 'big_key_in': ['Ice Palace - Spike Room', 'Ice Palace - Big Key Chest',
+                                                          'Ice Palace - Map Chest'], 'with_big_key': 1},
+        'Ice Tall Hint SE': 0, 'Ice Backwards Room Down Stairs': 2, 'Ice Switch Room ES': 2,
+    },
+    'Misery Mire': {
+        'Mire Hub WS': {'keys': 3, 'big_key_in': ['Misery Mire - Compass Chest', 'Misery Mire - Big Key Chest'],
+                        'with_big_key': 2},
+        'Mire Conveyor Crystal WS': {'keys': 3, 'big_key_in': ['Misery Mire - Compass Chest',
+                                                                'Misery Mire - Big Key Chest'], 'with_big_key': 2},
+        'Mire Hub Right EN': 1, 'Mire Spikes NW': 1, 'Mire Fishbone SE': 0, 'Mire Dark Shooters SE': 0,
+    },
+    'Turtle Rock': {  # most restrictive case; set_static_key_rules relaxes it by entrance access
+        'TR Hub NW': 4, 'TR Pokey 1 NW': 4, 'TR Chain Chomps Down Stairs': 4, 'TR Pokey 2 ES': 4,
+        'TR Crystaroller Down Stairs': 3, 'TR Dash Bridge WS': 4,
+    },
+    'Ganons Tower': {
+        'GT Torch EN': 0, 'GT Tile Room EN': 3,
+        'GT Hookshot ES': {'keys': 4, 'big_key_in': 'Ganons Tower - Map Chest', 'with_big_key': 3,
+                           'small_key_in': 'Ganons Tower - Map Chest', 'with_small_key': 3},
+        'GT Double Switch EN': 2, 'GT Firesnake Room SW': 3, 'GT Conveyor Star Pits EN': 3,
+        'GT Mini Helmasaur Room WN': 3, 'GT Crystal Circles SW': 4,
+    },
+}
+
+
+def static_logic_supported(world, player):
+    return (world.doorShuffle[player] == 'vanilla' and world.dropshuffle[player] == 'none'
+            and world.pottery[player] in ('none', 'cave'))
+
+
+def static_door_rules(world, player):
+    if not static_logic_supported(world, player):
+        raise Exception('static key logic needs vanilla doors, unshuffled key drops and unshuffled key pots')
+    specs = {}
+    for doors in DOOR_RULES.values():
+        for door, spec in doors.items():
+            spec = dict(spec) if isinstance(spec, dict) else {'keys': spec}
+            if 'big_key_in' in spec and isinstance(spec['big_key_in'], str):
+                spec['big_key_in'] = [spec['big_key_in']]
+            specs[door] = spec
+    apply_key_rule_specs(world, player, specs, chest_counting=True, validate=False)
+
+
+def set_static_key_rules(world, player):
+    from Rules import set_rule, add_rule, forbid_item, set_always_allow, item_in_locations, item_name
+
+    def keys(dungeon, count):
+        return lambda state: state.has_sm_key_strict(dungeon_keys[dungeon], player, count)
+
+    def big_key_in(dungeon, locations):
+        return lambda state: item_in_locations(state, dungeon_bigs[dungeon], player, [(x, player) for x in locations])
+
+    def small_key_at(dungeon, location):
+        return lambda state: item_name(state, location, player) == (dungeon_keys[dungeon], player)
+
+    def or_rules(*rules):
+        return lambda state: any(rule(state) for rule in rules)
+
+    def and_rules(*rules):
+        return lambda state: all(rule(state) for rule in rules)
+
+    def loc(name):
+        return world.get_location(name, player)
+
+    def allow_small(dungeon, location, extra=None):
+        # the fill may put the key here even though the chest is behind its own door
+        if world.accessibility[player] != 'locations':
+            key = dungeon_keys[dungeon]
+            set_always_allow(loc(location), lambda state, item: item.name == key and item.player == player
+                             and (extra is None or extra(state)))
+        else:
+            forbid_item(loc(location), dungeon_keys[dungeon], player)
+
+    if world.mode[player] != 'standard':
+        for name in ['Hyrule Castle - Boomerang Chest', "Hyrule Castle - Zelda's Chest"]:
+            add_rule(loc(name), keys('Hyrule Castle', 1))
+            forbid_item(loc(name), dungeon_keys['Hyrule Castle'], player)
+
+    for name in ['Desert Palace - Boss', 'Desert Palace - Prize']:
+        add_rule(loc(name), keys('Desert Palace', 1))
+    for name in ['Desert Palace - Boss', 'Desert Palace - Big Key Chest', 'Desert Palace - Compass Chest']:
+        forbid_item(loc(name), dungeon_keys['Desert Palace'], player)
+
+    allow_small('Tower of Hera', 'Tower of Hera - Big Key Chest')
+
+    allow_small('Palace of Darkness', 'Palace of Darkness - Big Key Chest', keys('Palace of Darkness', 5))
+    allow_small('Palace of Darkness', 'Palace of Darkness - Harmless Hellway', keys('Palace of Darkness', 5))
+
+    allow_small('Thieves Town', "Thieves' Town - Big Chest", lambda state: state.has('Hammer', player))
+    for name in ["Thieves' Town - Attic", "Thieves' Town - Boss"]:
+        forbid_item(loc(name), dungeon_keys['Thieves Town'], player)
+
+    forbid_item(loc('Skull Woods - Boss'), dungeon_keys['Skull Woods'], player)
+
+    # Kholdstare: 2 keys, or Somaria and 1
+    somaria = and_rules(lambda state: state.has('Cane of Somaria', player), keys('Ice Palace', 1))
+    for name in ['Ice Backwards Room Down Stairs', 'Ice Switch Room ES', 'Ice Refill WS']:
+        add_rule(world.get_entrance(name, player), somaria, 'or')
+
+    set_turtle_rock_rules(world, player, keys, big_key_in, small_key_at, or_rules, allow_small, forbid_item,
+                          set_rule, item_name, loc)
+
+    gt = 'Ganons Tower'
+    add_rule(loc('Ganons Tower - Firesnake Room'), or_rules(
+        keys(gt, 3), and_rules(or_rules(big_key_in(gt, GT_RANDOMIZER),
+                                        small_key_at(gt, 'Ganons Tower - Firesnake Room')), keys(gt, 2))))
+    for name in GT_RANDOMIZER:
+        add_rule(loc(name), or_rules(keys(gt, 4), and_rules(big_key_in(gt, GT_RANDOMIZER), keys(gt, 3))))
+    for name in GT_COMPASS:
+        add_rule(loc(name), or_rules(keys(gt, 4), and_rules(big_key_in(gt, GT_COMPASS), keys(gt, 3))))
+    allow_small(gt, 'Ganons Tower - Map Chest', keys(gt, 3))
+
+
+def set_door_number(world, player, door_name, number):
+    key_logic = world.key_logic[player]['Turtle Rock']
+    door = world.get_door(door_name, player)
+    for d in (door, key_logic.sm_doors.get(door)):
+        rule = key_logic.door_rules.get(d.name) if d else None
+        if rule:
+            rule.small_key_num = number
+            rule.new_rules[KeyRuleType.WorstCase] = number
+            for rule_type in list(rule.new_rules.keys()):
+                if rule_type != KeyRuleType.WorstCase and rule.new_rules[rule_type] >= number:
+                    del rule.new_rules[rule_type]
+
+
+def set_turtle_rock_rules(world, player, keys, big_key_in, small_key_at, or_rules, allow_small, forbid_item,
+                          set_rule, item_name, loc):
+    tr, chest = 'Turtle Rock', 'Turtle Rock - Big Key Chest'
+    # everything but this dungeon's small keys, so its key doors stay shut
+    from BaseClasses import CollectionState
+    full = world.get_all_state(keys=False)
+    state = CollectionState(world)
+    state.prog_items = full.prog_items.copy()
+    state.prog_items[(dungeon_keys[tr], player)] = 0
+
+    def reachable(region):
+        return world.get_region(region, player).can_reach(state)
+
+    back, front = reachable('TR Eye Bridge'), reachable('TR Main Lobby')
+    middle, big_chest = reachable('TR Lazy Eyes'), reachable('TR Big Chest Entrance')
+
+    def chest_keys_needed(state):
+        item = item_name(state, chest, player)
+        if item == (dungeon_keys[tr], player):
+            return 0
+        if item == (dungeon_bigs[tr], player):
+            return 2
+        return 4
+
+    no_big_key = ['Turtle Rock - Big Chest', 'Turtle Rock - Boss']
+    if back:
+        set_rule(loc(chest), or_rules(keys(tr, 4), small_key_at(tr, chest)))
+        set_door_number(world, player, 'TR Crystaroller Down Stairs', 4)
+        allow_small(tr, chest)
+    elif front and middle:
+        set_rule(loc(chest), lambda state: state.has_sm_key_strict(dungeon_keys[tr], player, chest_keys_needed(state)))
+        allow_small(tr, chest)
+        no_big_key += ['Turtle Rock - Crystaroller Room'] + TR_EYE_BRIDGE
+    elif front:
+        for door in ['TR Chain Chomps Down Stairs', 'TR Pokey 2 ES']:
+            set_door_number(world, player, door, 2)
+        for door in ['TR Hub NW', 'TR Pokey 1 NW']:
+            set_door_number(world, player, door, 1)
+        set_rule(loc(chest), lambda state: state.has_sm_key_strict(dungeon_keys[tr], player, chest_keys_needed(state)))
+        allow_small(tr, chest, keys(tr, 2))
+    elif big_chest:
+        # the doors back into the first section: 2 keys if the big key is in the first section, else 4
+        first_section = ['Turtle Rock - Compass Chest', 'Turtle Rock - Roller Room - Left', 'Turtle Rock - Roller Room - Right']
+        for door in ['TR Chain Chomps SW', 'TR Pokey 1 SW']:
+            rule = world.key_logic[player][tr].door_rules.get(door)
+            if rule:
+                rule.alternate_big_key_loc = {loc(x) for x in first_section}
+                rule.new_rules[(KeyRuleType.Lock, dungeon_bigs[tr])] = 2
+                rule.alternate_small_key = 2
+        set_rule(loc(chest), or_rules(keys(tr, 4), small_key_at(tr, chest)))
+        allow_small(tr, chest)
+        no_big_key += ['Turtle Rock - Crystaroller Room'] + TR_EYE_BRIDGE
+        if not world.bigkeyshuffle[player]:
+            no_big_key.append(chest)
+    for name in no_big_key:
+        forbid_item(loc(name), dungeon_bigs[tr], player)

--- a/source/dungeon/StaticKeyLogic.py
+++ b/source/dungeon/StaticKeyLogic.py
@@ -93,6 +93,20 @@ def static_door_rules(world, player):
                 spec['big_key_in'] = [spec['big_key_in']]
             specs[door] = spec
     apply_key_rule_specs(world, player, specs, chest_counting=True, validate=False)
+    # the analysis's own conditionals would let doors open with fewer keys than the table says
+    for door_name, spec in specs.items():
+        door = world.get_door(door_name, player)
+        for d, d_spec in ((door, spec), (door.dest, specs.get(door.dest.name, {}) if door.dest else None)):
+            key_logic = next((kl for kl in world.key_logic[player].values() if d and d.name in kl.door_rules), None)
+            if key_logic is None or d_spec is None:
+                continue
+            rule = key_logic.door_rules[d.name]
+            if 'big_key_in' not in d_spec:
+                rule.new_rules.pop((KeyRuleType.Lock, key_logic.bk_name), None)
+                rule.alternate_small_key, rule.alternate_big_key_loc = None, set()
+            if 'small_key_in' not in d_spec:
+                rule.new_rules.pop(KeyRuleType.AllowSmall, None)
+                rule.allow_small, rule.small_location = False, None
 
 
 def set_static_key_rules(world, player):

--- a/test/TestBase.py
+++ b/test/TestBase.py
@@ -1,7 +1,68 @@
 import unittest
 
-from BaseClasses import CollectionState
+from BaseClasses import CollectionState, World
+from CLI import parse_cli
+from DoorShuffle import link_doors, link_doors_prep
+from Doors import create_doors
+from Dungeons import create_dungeons
+from Fill import get_dungeon_item_pool
+from ItemList import difficulties, generate_itempool
+from Main import set_world_options
 from Items import ItemFactory
+from OverworldGlitchRules import create_owg_connections
+from OverworldShuffle import link_overworld, create_dynamic_exits
+from Regions import create_regions, create_dungeon_regions, create_shops, mark_light_dark_world_regions
+from RoomData import create_rooms
+from Rules import set_rules
+from source.classes.BabelFish import BabelFish
+from source.enemizer.DamageTables import DamageTable
+from source.item.FillUtil import create_item_pool_config
+from source.overworld.EntranceShuffle2 import link_entrances_new
+from source.rom.DataTables import init_data_tables
+
+PRIZES = ['Green Pendant', 'Red Pendant', 'Blue Pendant', 'Beat Agahnim 1', 'Beat Agahnim 2',
+          'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 5', 'Crystal 6', 'Crystal 7']
+
+
+def build_vanilla_world(mode='open', logic='noglitches'):
+    player = 1
+    args = parse_cli(['--mode', mode, '--logic', logic, '--shuffle', 'vanilla', '--door_shuffle', 'vanilla',
+                      '--intensity', '1', '--suppress_rom', '--spoiler', 'none'])
+    world = World(args.multi, args.shuffle, args.door_shuffle, args.logic, args.mode, args.swords,
+                  args.difficulty, args.item_functionality, args.timer, args.progressive, args.goal, args.algorithm,
+                  args.accessibility, args.shuffleganon, args.custom, args.customitemarray, args.hints, args.spoiler)
+    world.customizer = None
+    world.seed = 1
+    set_world_options(world, args, BabelFish(lang='en'))
+    world.difficulty_requirements[player] = difficulties[world.difficulty[player]]
+
+    create_regions(world, player)
+    if logic in ('owglitches', 'hybridglitches', 'nologic'):
+        create_owg_connections(world, player)
+    create_dungeon_regions(world, player)
+    create_shops(world, player)
+    create_doors(world, player)
+    create_rooms(world, player)
+    create_dungeons(world, player)
+    world.damage_table[player] = DamageTable()
+    world.data_tables[player] = init_data_tables(world, player)
+
+    link_overworld(world, player)
+    create_dynamic_exits(world, player)
+    link_entrances_new(world, player)
+    link_doors_prep(world, player)
+    create_item_pool_config(world)
+    link_doors(world, player)
+    mark_light_dark_world_regions(world, player)
+
+    generate_itempool(world, player)
+    world.required_medallions[player] = ['Ether', 'Quake']
+    world.itempool.extend(get_dungeon_item_pool(world))
+    world.itempool.extend(ItemFactory(PRIZES, player))
+    world.get_location('Agahnim 1', player).item = None
+    world.get_location('Agahnim 2', player).item = None
+    set_rules(world, player)
+    return world
 
 
 class TestBase(unittest.TestCase):
@@ -9,14 +70,15 @@ class TestBase(unittest.TestCase):
     _state_cache = {}
 
     def get_state(self, items):
-        if (self.world, tuple(items)) in self._state_cache:
-            return self._state_cache[self.world, tuple(items)]
+        key = (id(self.world), tuple((item.name, item.player) for item in items))
+        if key in self._state_cache:
+            return self._state_cache[key]
         state = CollectionState(self.world)
         for item in items:
             item.advancement = True
             state.collect(item)
         state.sweep_for_events()
-        self._state_cache[self.world, tuple(items)] = state
+        self._state_cache[key] = state
         return state
 
     def run_location_tests(self, access_pool):

--- a/test/TestBase.py
+++ b/test/TestBase.py
@@ -24,14 +24,14 @@ PRIZES = ['Green Pendant', 'Red Pendant', 'Blue Pendant', 'Beat Agahnim 1', 'Bea
           'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 5', 'Crystal 6', 'Crystal 7']
 
 
-def build_vanilla_world(mode='open', logic='noglitches'):
+def build_vanilla_world(mode='open', logic='noglitches', customizer=None):
     player = 1
     args = parse_cli(['--mode', mode, '--logic', logic, '--shuffle', 'vanilla', '--door_shuffle', 'vanilla',
                       '--intensity', '1', '--suppress_rom', '--spoiler', 'none'])
     world = World(args.multi, args.shuffle, args.door_shuffle, args.logic, args.mode, args.swords,
                   args.difficulty, args.item_functionality, args.timer, args.progressive, args.goal, args.algorithm,
                   args.accessibility, args.shuffleganon, args.custom, args.customitemarray, args.hints, args.spoiler)
-    world.customizer = None
+    world.customizer = customizer
     world.seed = 1
     set_world_options(world, args, BabelFish(lang='en'))
     world.difficulty_requirements[player] = difficulties[world.difficulty[player]]

--- a/test/TestBase.py
+++ b/test/TestBase.py
@@ -24,10 +24,11 @@ PRIZES = ['Green Pendant', 'Red Pendant', 'Blue Pendant', 'Beat Agahnim 1', 'Bea
           'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 5', 'Crystal 6', 'Crystal 7']
 
 
-def build_vanilla_world(mode='open', logic='noglitches', customizer=None):
+def build_vanilla_world(mode='open', logic='noglitches', customizer=None, key_logic='partial'):
     player = 1
     args = parse_cli(['--mode', mode, '--logic', logic, '--shuffle', 'vanilla', '--door_shuffle', 'vanilla',
-                      '--intensity', '1', '--suppress_rom', '--spoiler', 'none'])
+                      '--intensity', '1', '--suppress_rom', '--spoiler', 'none',
+                      '--key_logic_algorithm', key_logic])
     world = World(args.multi, args.shuffle, args.door_shuffle, args.logic, args.mode, args.swords,
                   args.difficulty, args.item_functionality, args.timer, args.progressive, args.goal, args.algorithm,
                   args.accessibility, args.shuffleganon, args.custom, args.customitemarray, args.hints, args.spoiler)

--- a/test/TestKeyLogicPlando.py
+++ b/test/TestKeyLogicPlando.py
@@ -1,0 +1,154 @@
+import unittest
+
+from BaseClasses import CollectionState, Entrance
+from Items import ItemFactory
+from KeyDoorShuffle import apply_custom_key_rules
+from source.classes.CustomSettings import CustomSettings
+from test.TestBase import build_vanilla_world
+
+
+def customizer(doors, counting='all'):
+    settings = CustomSettings()
+    settings.file_source = {'doors': {1: {'key_logic': {'counting': counting, 'doors': doors}}}}
+    return settings
+
+
+def add_start(world, region_name):
+    menu = world.get_region('Menu', 1)
+    start = Entrance(1, f'Test Start: {region_name}', menu)
+    start.connect(world.get_region(region_name, 1))
+    menu.exits.append(start)
+
+
+def can_reach(world, location, items):
+    state = CollectionState(world)
+    for item in ItemFactory(items, 1):
+        item.advancement = True
+        state.collect(item)
+    return world.get_location(location, 1).can_reach(state)
+
+
+# GT Hookshot ES: analyzed 8, two drops before it
+MAP_CHEST = 'Ganons Tower - Map Chest'
+MAP_CHEST_ITEMS = ['Hammer', 'Moon Pearl', 'Hookshot']
+GT_KEY = 'Small Key (Ganons Tower)'
+# chest counting needs every GT key door listed
+GT_DOORS = {'GT Torch EN': 0, 'GT Tile Room EN': 4, 'GT Hookshot ES': 4, 'GT Double Switch EN': 2,
+            'GT Firesnake Room SW': 4, 'GT Conveyor Star Pits EN': 4, 'GT Mini Helmasaur Room WN': 3,
+            'GT Crystal Circles SW': 4}
+
+
+def gt_doors(**overrides):
+    doors = dict(GT_DOORS)
+    doors.update(overrides)
+    return doors
+
+
+class TestKeyLogicPlando(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base = build_vanilla_world()
+        add_start(cls.base, 'Ganons Tower Portal')
+        cls.plando = build_vanilla_world(customizer=customizer({'GT Hookshot ES': 4}))
+        add_start(cls.plando, 'Ganons Tower Portal')
+        cls.chests = build_vanilla_world(customizer=customizer(gt_doors(), 'chests'))
+        add_start(cls.chests, 'Ganons Tower Portal')
+
+    def test_lowered_door_number_is_used(self):
+        rule = self.plando.key_logic[1]['Ganons Tower'].door_rules['GT Hookshot ES']
+        self.assertEqual(rule.small_key_num, 4)
+        self.assertEqual(rule.opposite.small_key_num, 4)
+        self.assertFalse(can_reach(self.base, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 2))
+        self.assertFalse(can_reach(self.plando, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 1))
+        self.assertTrue(can_reach(self.plando, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 2))
+
+    def test_chest_counting_ignores_drops(self):
+        self.assertTrue(self.chests.key_logic[1]['Ganons Tower'].chest_counting)
+        self.assertFalse(can_reach(self.chests, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 3))
+        self.assertTrue(can_reach(self.chests, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 4))
+
+    def test_lowering_keeps_alternatives_one_below(self):
+        rule = self.chests.key_logic[1]['Ganons Tower'].door_rules['GT Hookshot ES']
+        alternatives = {k: v for k, v in rule.new_rules.items() if k != 0}
+        self.assertEqual(len(alternatives), 2)
+        self.assertTrue(all(v == 3 for v in alternatives.values()))
+        self.assertEqual(rule.alternate_small_key, 3)
+
+    def test_explicit_conditionals(self):
+        hookshot = {'keys': 4, 'big_key_in': [MAP_CHEST], 'with_big_key': 2,
+                    'small_key_in': MAP_CHEST, 'with_small_key': 3}
+        world = build_vanilla_world(customizer=customizer(gt_doors(**{'GT Hookshot ES': hookshot}), 'chests'))
+        add_start(world, 'Ganons Tower Portal')
+        spot = world.get_location(MAP_CHEST, 1)
+        self.assertFalse(can_reach(world, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 3))
+        spot.item = ItemFactory('Small Key (Ganons Tower)', 1)
+        self.assertTrue(can_reach(world, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 3))
+        self.assertFalse(can_reach(world, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 2))
+        spot.item = ItemFactory('Big Key (Ganons Tower)', 1)
+        self.assertTrue(can_reach(world, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 2))
+        self.assertFalse(can_reach(world, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 1))
+
+    def test_naming_the_paired_side_applies_to_both(self):
+        world = build_vanilla_world(customizer=customizer({'GT Map Room WS': 4}))
+        add_start(world, 'Ganons Tower Portal')
+        self.assertEqual(world.key_logic[1]['Ganons Tower'].door_rules['GT Hookshot ES'].small_key_num, 4)
+        self.assertTrue(can_reach(world, MAP_CHEST, MAP_CHEST_ITEMS + [GT_KEY] * 2))
+
+    def test_each_side_can_differ_when_both_are_listed(self):
+        world = self.base
+        world.customizer = customizer({'PoD Middle Cage N': 2, 'PoD Pit Room S': 5})
+        try:
+            apply_custom_key_rules(world, 1)
+            rules = world.key_logic[1]['Palace of Darkness'].door_rules
+            self.assertEqual(rules['PoD Middle Cage N'].small_key_num, 2)
+            self.assertEqual(rules['PoD Pit Room S'].small_key_num, 5)
+        finally:
+            world.customizer = None
+
+    def test_unlisted_pair_side_keeps_its_own_minimum(self):
+        world = self.base
+        world.customizer = customizer({'Sewers Secret Room Key Door S': 1})
+        try:
+            apply_custom_key_rules(world, 1)
+            rules = world.key_logic[1]['Hyrule Castle'].door_rules
+            self.assertEqual(rules['Sewers Secret Room Key Door S'].small_key_num, 1)
+            # floor is 2 (behind Dark Cross)
+            self.assertEqual(rules['Sewers Key Rat NE'].small_key_num, 2)
+        finally:
+            world.customizer = None
+
+    def test_invalid_numbers_and_doors_are_rejected(self):
+        world = self.base
+        for bad, counting, message in [({'GT Hookshot ES': 0}, 'all', 'fewer than 1'),
+                                       ({'GT Hookshot ES': 9}, 'all', 'only has 8'),
+                                       (gt_doors(**{'GT Hookshot ES': 5}), 'chests', 'only has 4'),
+                                       ({'GT Hookshot ES': 4}, 'chests', 'every key door'),
+                                       ({'GT Hope Room EN': 1}, 'all', 'not a small key door')]:
+            world.customizer = customizer(bad, counting)
+            try:
+                with self.assertRaisesRegex(Exception, message):
+                    apply_custom_key_rules(world, 1)
+            finally:
+                world.customizer = None
+        for bad in [{'GT Hookshot ES': 'four'}, {'GT Hookshot ES': {'keys': 4, 'with_big_key': 5}},
+                    {'GT Hookshot ES': {'big_key_in': [MAP_CHEST]}}]:
+            with self.assertRaises(Exception):
+                customizer(bad).get_key_logic(1)
+        with self.assertRaisesRegex(Exception, 'counting'):
+            customizer({'GT Hookshot ES': 4}, 'drops').get_key_logic(1)
+
+    def test_export_records_every_door_side(self):
+        settings = CustomSettings()
+        settings.player_range = range(1, 2)
+        settings.record_doors(self.chests)
+        exported = settings.world_rep['doors'][1]['key_logic']
+        self.assertEqual(exported['counting'], 'chests')
+        self.assertEqual(exported['doors']['GT Hookshot ES'], 4)
+        self.assertEqual(exported['doors']['GT Map Room WS'], 4)
+        self.assertEqual(exported['doors']['PoD Middle Cage N'], 1)
+        self.assertEqual(exported['doors']['PoD Pit Room S'], 6)
+        self.assertNotIn('Mire Hub Upper Blue Barrier', exported['doors'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/TestStaticKeyLogic.py
+++ b/test/TestStaticKeyLogic.py
@@ -1,0 +1,125 @@
+import unittest
+
+from BaseClasses import CollectionState, Entrance
+from Items import ItemFactory
+from test.TestBase import build_vanilla_world
+
+KEYS = {'Ganons Tower': 'Small Key (Ganons Tower)', 'Hyrule Castle': 'Small Key (Escape)',
+        'Turtle Rock': 'Small Key (Turtle Rock)', 'Palace of Darkness': 'Small Key (Palace of Darkness)',
+        'Ice Palace': 'Small Key (Ice Palace)', 'Misery Mire': 'Small Key (Misery Mire)'}
+
+
+class TestStaticKeyLogic(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.world = build_vanilla_world(key_logic='static')
+        menu = cls.world.get_region('Menu', 1)
+        for name in ['Ganons Tower Portal', 'Hyrule Castle South Portal', 'Turtle Rock Main Portal',
+                     'Palace of Darkness Portal', 'Ice Portal', 'Mire Portal']:
+            start = Entrance(1, f'Test Start: {name}', menu)
+            start.connect(cls.world.get_region(name, 1))
+            menu.exits.append(start)
+        cls.items = sorted({i.name for i in cls.world.itempool if (i.advancement or i.bigkey) and not i.smallkey})
+
+    def state(self, dungeon, keys, without=()):
+        state = CollectionState(self.world)
+        names = [n for n in self.items if n not in without] + [KEYS[dungeon]] * keys
+        for item in ItemFactory(names, 1):
+            item.advancement = True
+            state.collect(item)
+        return state
+
+    def min_keys(self, location, dungeon, without=()):
+        for keys in range(0, 7):
+            if self.world.get_location(location, 1).can_reach(self.state(dungeon, keys, without)):
+                return keys
+        return None
+
+    def place(self, location, item):
+        self.world.get_location(location, 1).item = ItemFactory(item, 1) if item else None
+
+    def test_ganons_tower_chest_rules(self):
+        gt = 'Ganons Tower'
+        self.assertEqual(self.min_keys('Ganons Tower - Map Chest', gt), 4)
+        self.assertEqual(self.min_keys('Ganons Tower - Randomizer Room - Top Left', gt), 4)
+        self.assertEqual(self.min_keys('Ganons Tower - Compass Room - Top Left', gt), 4)
+        self.assertEqual(self.min_keys('Ganons Tower - Firesnake Room', gt), 3)
+        self.assertEqual(self.min_keys("Ganons Tower - Bob's Chest", gt), 3)
+        self.assertEqual(self.min_keys('Ganons Tower - Big Key Chest', gt), 3)
+        self.assertEqual(self.min_keys('Ganons Tower - Mini Helmasaur Room - Left', gt), 0)
+        self.assertEqual(self.min_keys('Ganons Tower - Pre-Moldorm Chest', gt), 3)
+        self.assertEqual(self.min_keys('Ganons Tower - Validation Chest', gt), 4)
+
+    def test_ganons_tower_big_key_conditionals(self):
+        gt = 'Ganons Tower'
+        self.place('Ganons Tower - Randomizer Room - Bottom Right', 'Big Key (Ganons Tower)')
+        try:
+            self.assertEqual(self.min_keys('Ganons Tower - Randomizer Room - Top Left', gt), 3)
+            self.assertEqual(self.min_keys('Ganons Tower - Firesnake Room', gt), 2)
+            self.assertEqual(self.min_keys('Ganons Tower - Compass Room - Top Left', gt), 4)
+        finally:
+            self.place('Ganons Tower - Randomizer Room - Bottom Right', None)
+        self.place('Ganons Tower - Map Chest', 'Big Key (Ganons Tower)')
+        try:
+            self.assertEqual(self.min_keys('Ganons Tower - Map Chest', gt), 3)
+        finally:
+            self.place('Ganons Tower - Map Chest', None)
+
+    def test_hyrule_castle_open_mode(self):
+        self.assertEqual(self.min_keys('Hyrule Castle - Boomerang Chest', 'Hyrule Castle'), 1)
+        self.assertEqual(self.min_keys("Hyrule Castle - Zelda's Chest", 'Hyrule Castle'), 1)
+        self.assertEqual(self.min_keys('Hyrule Castle - Map Chest', 'Hyrule Castle'), 0)
+        self.assertFalse(self.world.get_location('Hyrule Castle - Boomerang Chest', 1).item_rule(ItemFactory('Small Key (Escape)', 1)))
+
+    def test_palace_of_darkness(self):
+        pod = 'Palace of Darkness'
+        self.assertEqual(self.min_keys('Palace of Darkness - Big Key Chest', pod), 6)
+        self.assertEqual(self.min_keys('Palace of Darkness - Compass Chest', pod), 4)
+        self.place('Palace of Darkness - Big Key Chest', 'Small Key (Palace of Darkness)')
+        try:
+            self.assertEqual(self.min_keys('Palace of Darkness - Big Key Chest', pod), 3)
+        finally:
+            self.place('Palace of Darkness - Big Key Chest', None)
+
+    def test_turtle_rock_front_access(self):
+        # vanilla entrances only reach Turtle Rock from the front: Pokey Room 1, North 2, Dark Room Staircase 3
+        tr = 'Turtle Rock'
+        self.assertEqual(self.min_keys('Turtle Rock - Chain Chomps', tr), 1)
+        self.assertEqual(self.min_keys('Turtle Rock - Big Key Chest', tr), 4)
+        self.assertEqual(self.min_keys('Turtle Rock - Big Chest', tr), 2)
+        self.assertEqual(self.min_keys('Turtle Rock - Crystaroller Room', tr), 2)
+        self.assertEqual(self.min_keys('Turtle Rock - Eye Bridge - Top Left', tr), 3)
+        self.assertEqual(self.min_keys('Turtle Rock - Boss', tr), 4)
+        self.place('Turtle Rock - Big Key Chest', 'Big Key (Turtle Rock)')
+        try:
+            self.assertEqual(self.min_keys('Turtle Rock - Big Key Chest', tr), 2)
+        finally:
+            self.place('Turtle Rock - Big Key Chest', None)
+        self.assertFalse(self.world.get_location('Turtle Rock - Big Chest', 1).item_rule(ItemFactory('Big Key (Turtle Rock)', 1)))
+
+    def test_kholdstare_somaria_alternative(self):
+        ice = 'Ice Palace'
+        self.assertEqual(self.min_keys('Ice Palace - Boss', ice), 1)
+        self.assertEqual(self.min_keys('Ice Palace - Boss', ice, without=['Cane of Somaria']), 2)
+
+    def test_mire_west_wing(self):
+        mire = 'Misery Mire'
+        self.assertEqual(self.min_keys('Misery Mire - Compass Chest', mire), 3)
+        self.place('Misery Mire - Big Key Chest', 'Big Key (Misery Mire)')
+        try:
+            self.assertEqual(self.min_keys('Misery Mire - Compass Chest', mire), 2)
+        finally:
+            self.place('Misery Mire - Big Key Chest', None)
+
+    def test_requires_vanilla_doors(self):
+        from source.dungeon.StaticKeyLogic import static_logic_supported
+        self.assertTrue(static_logic_supported(self.world, 1))
+        self.world.dropshuffle[1] = 'keys'
+        try:
+            self.assertFalse(static_logic_supported(self.world, 1))
+        finally:
+            self.world.dropshuffle[1] = 'none'
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/TestStaticKeyLogic.py
+++ b/test/TestStaticKeyLogic.py
@@ -65,6 +65,18 @@ class TestStaticKeyLogic(unittest.TestCase):
         finally:
             self.place('Ganons Tower - Map Chest', None)
 
+    def test_ganons_tower_bottom_always_three_keys(self):
+        gt = 'Ganons Tower'
+        bottom = ["Ganons Tower - Bob's Chest", 'Ganons Tower - Big Key Chest', 'Ganons Tower - Big Chest',
+                  'Ganons Tower - Big Key Room - Left', 'Ganons Tower - Big Key Room - Right']
+        for where in bottom + ['Ganons Tower - Randomizer Room - Top Left', 'Ganons Tower - Compass Room - Top Left']:
+            self.place(where, 'Big Key (Ganons Tower)')
+            try:
+                for name in bottom:
+                    self.assertEqual(self.min_keys(name, gt), 3, f'{name} with big key at {where}')
+            finally:
+                self.place(where, None)
+
     def test_hyrule_castle_open_mode(self):
         self.assertEqual(self.min_keys('Hyrule Castle - Boomerang Chest', 'Hyrule Castle'), 1)
         self.assertEqual(self.min_keys("Hyrule Castle - Zelda's Chest", 'Hyrule Castle'), 1)

--- a/test/customizer/key_logic_plando.yaml
+++ b/test/customizer/key_logic_plando.yaml
@@ -1,0 +1,29 @@
+meta:
+  players: 1
+settings:
+  1:
+    door_shuffle: vanilla
+    shuffle: vanilla
+    mode: open
+doors:
+  1:
+    key_logic:
+      counting: chests
+      doors:
+        GT Torch EN: 0
+        GT Tile Room EN: 4
+        GT Hookshot ES:
+          keys: 4
+          big_key_in: Ganons Tower - Map Chest
+          small_key_in: Ganons Tower - Map Chest
+        GT Double Switch EN: 2
+        GT Firesnake Room SW: 4
+        GT Conveyor Star Pits EN: 4
+        GT Mini Helmasaur Room WN: 3
+        GT Crystal Circles SW: 4
+        PoD Middle Cage N: 1
+        PoD Arena Main NW: 4
+        PoD Falling Bridge WN: 6
+        PoD Basement Ledge Up Stairs: 6
+        PoD Compass Room SE: 6
+        PoD Dark Pegs WN: 6

--- a/test/dungeons/TestDungeon.py
+++ b/test/dungeons/TestDungeon.py
@@ -1,35 +1,45 @@
 import unittest
 
-from BaseClasses import World, CollectionState
-from Dungeons import create_dungeons, get_dungeon_item_pool
-from ItemList import difficulties, generate_itempool
+from BaseClasses import CollectionState, Entrance
 from Items import ItemFactory
-from Regions import create_regions
-from Rules import set_rules
-from source.overworld.EntranceShuffle2 import mandatory_connections, connect_simple
+from test.TestBase import build_vanilla_world
+
+
+# old test region names -> current portal/drop regions
+STARTING_REGION_MAP = {
+    'Eastern Palace': ['Eastern Portal'],
+    'Agahnims Tower': ['Agahnims Tower Portal'],
+    'Desert Palace North': ['Desert Back Portal'],
+    'Desert Palace Main (Inner)': ['Desert South Portal'],
+    'Desert Palace Main (Outer)': ['Desert West Portal', 'Desert East Portal'],
+    'Ganons Tower (Entrance)': ['Ganons Tower Portal'],
+    'Ice Palace (Entrance)': ['Ice Portal'],
+    'Misery Mire (Entrance)': ['Mire Portal'],
+    'Palace of Darkness (Entrance)': ['Palace of Darkness Portal'],
+    'Skull Woods First Section': ['Skull 1 Portal', 'Skull Pinball'],
+    'Skull Woods First Section (Left)': ['Skull Left Drop'],
+    'Skull Woods First Section (Top)': ['Skull Pot Circle'],
+    'Skull Woods Second Section': ['Skull 2 East Portal', 'Skull 2 West Portal', 'Skull Back Drop'],
+    'Skull Woods Final Section (Entrance)': ['Skull 3 Portal'],
+    'Swamp Palace (Entrance)': ['Swamp Portal'],
+    'Thieves Town (Entrance)': ['Thieves Town Portal'],
+    'Tower of Hera (Bottom)': ['Hera Portal'],
+}
 
 
 class TestDungeon(unittest.TestCase):
     def setUp(self):
-        self.world = World(1, 'vanilla', 'noglitches', 'open', 'random', 'normal', 'normal', 'none', 'on', 'ganon', 'balanced',
-                           True, False, False, False, False, False, False, False, False, None,
-                           'none', False)
+        self.world = build_vanilla_world()
         self.starting_regions = []
-        self.world.difficulty_requirements = difficulties['normal']
-        create_regions(self.world, 1)
-        create_dungeons(self.world, 1)
-        for exitname, regionname in mandatory_connections:
-            connect_simple(self.world, exitname, regionname, 1)
-        connect_simple(self.world, self.world.get_entrance('Big Bomb Shop', 1), self.world.get_region('Big Bomb Shop', 1), 1)
-        self.world.swamp_patch_required[1] = True
-        set_rules(self.world, 1)
-        generate_itempool(self.world, 1)
-        self.world.itempool.extend(get_dungeon_item_pool(self.world))
-        self.world.itempool.extend(ItemFactory(['Green Pendant', 'Red Pendant', 'Blue Pendant', 'Beat Agahnim 1', 'Beat Agahnim 2', 'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 5', 'Crystal 6', 'Crystal 7'], 1))
 
     def run_tests(self, access_pool):
+        # start regions hang off Menu
+        menu = self.world.get_region('Menu', 1)
         for region in self.starting_regions:
-            self.world.get_region(region, 1).can_reach_private = lambda _: True
+            for region_name in STARTING_REGION_MAP.get(region, [region]):
+                exit = Entrance(1, f'Test Start: {region_name}', menu)
+                exit.connect(self.world.get_region(region_name, 1))
+                menu.exits.append(exit)
 
         for location, access, *item_pool in access_pool:
             items = item_pool[0]

--- a/test/inverted/TestInverted.py
+++ b/test/inverted/TestInverted.py
@@ -1,38 +1,6 @@
-from BaseClasses import World
-from DoorShuffle import link_doors
-from Doors import create_doors
-from Dungeons import create_dungeons, get_dungeon_item_pool
-from OverworldShuffle import link_overworld
-from ItemList import generate_itempool, difficulties
-from Items import ItemFactory
-from Regions import create_regions, mark_light_dark_world_regions, create_dungeon_regions, create_shops
-from RoomData import create_rooms
-from Rules import set_rules
-
-from source.overworld.EntranceShuffle2 import link_entrances_new
-from test.TestBase import TestBase
+from test.TestBase import TestBase, build_vanilla_world
 
 
 class TestInverted(TestBase):
     def setUp(self):
-        self.world = World(1, {1: 'vanilla'}, {1: 'vanilla'}, {1: 'noglitches'}, {1: 'inverted'}, {1: 'random'}, {1: 'normal'}, {1: 'normal'}, 'none', 'on', {1: 'ganon'}, 'balanced', {1: 'items'},
-                           {1: True}, {1: False}, False, None, {1: False})
-        self.world.difficulty_requirements[1] = difficulties['normal']
-        self.world.intensity = {1: 1}
-        create_regions(self.world, 1)
-        create_dungeon_regions(self.world, 1)
-        create_shops(self.world, 1)
-        create_doors(self.world, 1)
-        create_rooms(self.world, 1)
-        create_dungeons(self.world, 1)
-        link_overworld(self.world, 1)
-        link_entrances_new(self.world, 1)
-        link_doors(self.world, 1)
-        generate_itempool(self.world, 1)
-        self.world.required_medallions[1] = ['Ether', 'Quake']
-        self.world.itempool.extend(get_dungeon_item_pool(self.world))
-        self.world.itempool.extend(ItemFactory(['Green Pendant', 'Red Pendant', 'Blue Pendant', 'Beat Agahnim 1', 'Beat Agahnim 2', 'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 5', 'Crystal 6', 'Crystal 7'], 1))
-        self.world.get_location('Agahnim 1', 1).item = None
-        self.world.get_location('Agahnim 2', 1).item = None
-        mark_light_dark_world_regions(self.world, 1)
-        set_rules(self.world, 1)
+        self.world = build_vanilla_world(mode='inverted', logic='noglitches')

--- a/test/inverted/TestInvertedBombRules.py
+++ b/test/inverted/TestInvertedBombRules.py
@@ -1,44 +1,41 @@
-import unittest
-
-from BaseClasses import World
-from Dungeons import create_dungeons
-# todo: this test needs to be rewritten unfortunately
-from source.overworld.EntranceShuffle2 import connect_entrance, Inverted_LW_Entrances, Inverted_LW_Dungeon_Entrances, Inverted_LW_Single_Cave_Doors, Inverted_Old_Man_Entrances, Inverted_DW_Entrances, Inverted_DW_Dungeon_Entrances, Inverted_DW_Single_Cave_Doors, \
-    Inverted_LW_Entrances_Must_Exit, Inverted_LW_Dungeon_Entrances_Must_Exit, Inverted_Bomb_Shop_Multi_Cave_Doors, Inverted_Bomb_Shop_Single_Cave_Doors, Inverted_Blacksmith_Single_Cave_Doors, Inverted_Blacksmith_Multi_Cave_Doors
-from Regions import create_regions
-from ItemList import difficulties
+from source.overworld.EntranceShuffle2 import Inverted_Bomb_Shop_Options
 from Rules import set_inverted_big_bomb_rules
 from test.inverted.TestInverted import TestInverted
 
 
 class TestInvertedBombRules(TestInverted):
 
+    invalid_entrances = ['Desert Palace Entrance (East)', 'Spectacle Rock Cave', 'Spectacle Rock Cave (Bottom)', 'Pyramid Fairy']
+
+    def connect_bomb_shop(self, entrance_name):
+        entrance = self.world.get_entrance(entrance_name, 1)
+        bomb_shop = self.world.get_region('Big Bomb Shop', 1)
+        if entrance.connected_region is not None and entrance in entrance.connected_region.entrances:
+            entrance.connected_region.entrances.remove(entrance)
+        bomb_shop.entrances = []
+        entrance.connect(bomb_shop)
+        return entrance
+
+    def disconnect(self, entrance):
+        entrance.connected_region.entrances.remove(entrance)
+        entrance.connected_region = None
+
     #TODO: Just making sure I haven't missed an entrance.  It would be good to test the rules make sense as well.
     def testInvertedBombRulesAreComplete(self):
-        entrances = list(Inverted_LW_Entrances + Inverted_LW_Dungeon_Entrances + Inverted_LW_Single_Cave_Doors + Inverted_Old_Man_Entrances + Inverted_DW_Entrances + Inverted_DW_Dungeon_Entrances + Inverted_DW_Single_Cave_Doors)
-        must_exits = list(Inverted_LW_Entrances_Must_Exit + Inverted_LW_Dungeon_Entrances_Must_Exit)
-        for entrance_name in (entrances + must_exits):
-            if entrance_name not in ['Desert Palace Entrance (East)', 'Spectacle Rock Cave', 'Spectacle Rock Cave (Bottom)']:
-                entrance = self.world.get_entrance(entrance_name, 1)
-                entrance.connected_region = None
-                self.world.get_region('Big Bomb Shop', 1).entrances = []
-                connect_entrance(self.world, entrance, 'Big Bomb Shop', 1)
+        for entrance_name in Inverted_Bomb_Shop_Options:
+            with self.subTest(entrance=entrance_name):
+                entrance = self.connect_bomb_shop(entrance_name)
                 set_inverted_big_bomb_rules(self.world, 1)
-                entrance.connected_region.entrances.remove(entrance)
-                entrance.connected_region = None
+                self.disconnect(entrance)
 
     def testInvalidEntrancesAreNotUsed(self):
-        entrances = list(Inverted_Blacksmith_Multi_Cave_Doors + Inverted_Blacksmith_Single_Cave_Doors + Inverted_Bomb_Shop_Multi_Cave_Doors + Inverted_Bomb_Shop_Single_Cave_Doors)
-        invalid_entrances = ['Desert Palace Entrance (East)', 'Spectacle Rock Cave', 'Spectacle Rock Cave (Bottom)', 'Pyramid Fairy']
-        for invalid_entrance in invalid_entrances:
-            self.assertNotIn(invalid_entrance, entrances)
+        for invalid_entrance in self.invalid_entrances:
+            self.assertNotIn(invalid_entrance, Inverted_Bomb_Shop_Options)
 
     def testInvalidEntrances(self):
-        for entrance_name in ['Desert Palace Entrance (East)', 'Spectacle Rock Cave', 'Spectacle Rock Cave (Bottom)']:
-            entrance = self.world.get_entrance(entrance_name, 1)
-            self.world.get_region('Big Bomb Shop', 1).entrances = []
-            connect_entrance(self.world, entrance, 'Big Bomb Shop', 1)
-            with self.assertRaises(Exception):
-                set_inverted_big_bomb_rules(self.world, 1)
-            entrance.connected_region.entrances.remove(entrance)
-            entrance.connected_region = None
+        for entrance_name in self.invalid_entrances[:3]:
+            with self.subTest(entrance=entrance_name):
+                entrance = self.connect_bomb_shop(entrance_name)
+                with self.assertRaises(Exception):
+                    set_inverted_big_bomb_rules(self.world, 1)
+                self.disconnect(entrance)

--- a/test/inverted_owg/TestInvertedOWG.py
+++ b/test/inverted_owg/TestInvertedOWG.py
@@ -1,41 +1,9 @@
-from BaseClasses import World
-from DoorShuffle import link_doors
-from Doors import create_doors
-from Dungeons import create_dungeons, get_dungeon_item_pool
-from OverworldShuffle import link_overworld
-from source.overworld.EntranceShuffle2 import link_entrances_new
-from ItemList import generate_itempool, difficulties
 from Items import ItemFactory
-from OverworldGlitchRules import create_owg_connections
-from Regions import create_regions, mark_light_dark_world_regions, create_dungeon_regions, create_shops
-from RoomData import create_rooms
-from Rules import set_rules
-from test.TestBase import TestBase
+from test.TestBase import TestBase, build_vanilla_world
 
 
 class TestInvertedOWG(TestBase):
     def setUp(self):
-        self.world = World(1, {1: 'vanilla'}, {1: 'vanilla'}, {1: 'owglitches'}, {1: 'inverted'}, {1: 'random'}, {1: 'normal'}, {1: 'normal'}, 'none', 'on', {1: 'ganon'}, 'balanced', {1: 'items'},
-                           {1: True}, {1: False}, False, None, {1: False})
-        self.world.difficulty_requirements[1] = difficulties['normal']
-        self.world.intensity = {1: 1}
-        create_regions(self.world, 1)
-        create_dungeon_regions(self.world, 1)
-        create_shops(self.world, 1)
-        create_doors(self.world, 1)
-        create_rooms(self.world, 1)
-        create_dungeons(self.world, 1)
-        link_overworld(self.world, 1)
-        create_owg_connections(self.world, 1)
-        link_entrances_new(self.world, 1)
-        link_doors(self.world, 1)
-        generate_itempool(self.world, 1)
-        self.world.required_medallions[1] = ['Ether', 'Quake']
-        self.world.itempool.extend(get_dungeon_item_pool(self.world))
-        self.world.itempool.extend(ItemFactory(['Green Pendant', 'Red Pendant', 'Blue Pendant', 'Beat Agahnim 1', 'Beat Agahnim 2', 'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 5', 'Crystal 6', 'Crystal 7'], 1))
-        self.world.get_location('Agahnim 1', 1).item = None
-        self.world.get_location('Agahnim 2', 1).item = None
+        self.world = build_vanilla_world(mode='inverted', logic='owglitches')
         self.world.precollected_items.clear()
         self.world.itempool.append(ItemFactory('Pegasus Boots', 1))
-        mark_light_dark_world_regions(self.world, 1)
-        set_rules(self.world, 1)

--- a/test/owg/TestVanillaOWG.py
+++ b/test/owg/TestVanillaOWG.py
@@ -1,41 +1,9 @@
-from BaseClasses import World
-from DoorShuffle import link_doors
-from Doors import create_doors
-from Dungeons import create_dungeons, get_dungeon_item_pool
-from OverworldShuffle import link_overworld
-from source.overworld.EntranceShuffle2 import link_entrances_new
-from ItemList import difficulties, generate_itempool
 from Items import ItemFactory
-from OverworldGlitchRules import create_owg_connections
-from Regions import create_regions, create_dungeon_regions, create_shops, mark_light_dark_world_regions
-from RoomData import create_rooms
-from Rules import set_rules
-from test.TestBase import TestBase
+from test.TestBase import TestBase, build_vanilla_world
 
 
 class TestVanillaOWG(TestBase):
     def setUp(self):
-        self.world = World(1, {1:'vanilla'}, {1:'vanilla'}, {1:'owglitches'}, {1:'open'}, {1:'random'}, {1:'normal'}, {1:'normal'}, 'none', 'on', {1:'ganon'}, 'balanced', {1:'items'},
-                           {1:True}, {1:False}, False, None, {1:False})
-        self.world.difficulty_requirements[1] = difficulties['normal']
-        self.world.intensity = {1:1}
-        create_regions(self.world, 1)
-        create_dungeon_regions(self.world, 1)
-        create_shops(self.world, 1)
-        create_doors(self.world, 1)
-        create_rooms(self.world, 1)
-        create_dungeons(self.world, 1)
-        link_overworld(self.world, 1)
-        link_entrances_new(self.world, 1)
-        link_doors(self.world, 1)
-        create_owg_connections(self.world, 1)
-        generate_itempool(self.world, 1)
-        self.world.required_medallions[1] = ['Ether', 'Quake']
-        self.world.itempool.extend(get_dungeon_item_pool(self.world))
-        self.world.itempool.extend(ItemFactory(['Green Pendant', 'Red Pendant', 'Blue Pendant', 'Beat Agahnim 1', 'Beat Agahnim 2', 'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 5', 'Crystal 6', 'Crystal 7'], 1))
-        self.world.get_location('Agahnim 1', 1).item = None
-        self.world.get_location('Agahnim 2', 1).item = None
+        self.world = build_vanilla_world(mode='open', logic='owglitches')
         self.world.precollected_items.clear()
         self.world.itempool.append(ItemFactory('Pegasus Boots', 1))
-        mark_light_dark_world_regions(self.world, 1)
-        set_rules(self.world, 1)

--- a/test/vanilla/TestVanilla.py
+++ b/test/vanilla/TestVanilla.py
@@ -1,37 +1,6 @@
-from BaseClasses import World
-from DoorShuffle import link_doors
-from Doors import create_doors
-from Dungeons import create_dungeons, get_dungeon_item_pool
-from OverworldShuffle import link_overworld
-from source.overworld.EntranceShuffle2 import link_entrances_new
-from ItemList import difficulties, generate_itempool
-from Items import ItemFactory
-from Regions import create_regions, create_dungeon_regions, create_shops, mark_light_dark_world_regions
-from RoomData import create_rooms
-from Rules import set_rules
-from test.TestBase import TestBase
+from test.TestBase import TestBase, build_vanilla_world
 
 
 class TestVanilla(TestBase):
     def setUp(self):
-        self.world = World(1, {1:'vanilla'}, {1:'vanilla'}, {1:'noglitches'}, {1:'open'}, {1:'random'}, {1:'normal'}, {1:'normal'}, 'none', 'on', {1:'ganon'}, 'balanced', {1:'items'},
-                           {1:True}, {1:False}, False, None, {1:False})
-        self.world.difficulty_requirements[1] = difficulties['normal']
-        self.world.intensity = {1:1}
-        create_regions(self.world, 1)
-        create_dungeon_regions(self.world, 1)
-        create_shops(self.world, 1)
-        create_doors(self.world, 1)
-        create_rooms(self.world, 1)
-        create_dungeons(self.world, 1)
-        link_overworld(self.world, 1)
-        link_entrances_new(self.world, 1)
-        link_doors(self.world, 1)
-        generate_itempool(self.world, 1)
-        self.world.required_medallions[1] = ['Ether', 'Quake']
-        self.world.itempool.extend(get_dungeon_item_pool(self.world))
-        self.world.itempool.extend(ItemFactory(['Green Pendant', 'Red Pendant', 'Blue Pendant', 'Beat Agahnim 1', 'Beat Agahnim 2', 'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 5', 'Crystal 6', 'Crystal 7'], 1))
-        self.world.get_location('Agahnim 1', 1).item = None
-        self.world.get_location('Agahnim 2', 1).item = None
-        mark_light_dark_world_regions(self.world, 1)
-        set_rules(self.world, 1)
+        self.world = build_vanilla_world(mode='open', logic='noglitches')


### PR DESCRIPTION
Adds `key_logic_algorithm: static` and a customizer section for key door logic, with the unit test harness they need.

**Static key logic** (`source/dungeon/StaticKeyLogic.py`): ER's key rules for the vanilla dungeon layouts, counting chest keys only as ER's `has_key` does. Requires vanilla doors and unshuffled key drops and key pots; entrance shuffle is allowed, and Turtle Rock picks its front, middle, back or big chest case from which portals are reachable. The door table is applied at the end of `link_doors` through `KeyDoorShuffle.apply_key_rule_specs`; `set_static_key_rules` inside `set_rules` carries what a door number cannot (GT randomizer, compass and firesnake chests with their big-key-in-room alternatives, open-mode Boomerang and Zelda's chests, the Kholdstare Somaria alternative, and the key forbids and always-allows). The door evaluators use `has_sm_key_strict` when a dungeon's key logic counts chest keys. The key placement validator still runs on top.

**Key door logic in the customizer** (`doors.<player>.key_logic`, documented in docs/Customizer.md): sets the number of small keys the logic requires per key door. `counting: all` counts every key held, the analyzed unit; `counting: chests` counts chest keys only and needs every key door of the dungeon listed. A door takes a number, or `keys` with `big_key_in`/`with_big_key` and `small_key_in`/`with_small_key`. Values above the dungeon's key count, doors that are not key doors in the final layout, and the strict algorithm are rejected; universal keys skip the section. `--print_custom_yaml` exports the numbers in force.

**Test harness**: `pytest` runs from the repo root (`pytest.ini`). `Main.set_world_options` is split out of `main` so `test/TestBase.build_vanilla_world` builds a world with the same option handling, and the vanilla, owg, inverted and dungeon suites use it.

Testing
- `pytest test/vanilla test/TestKeyLogicPlando.py test/TestStaticKeyLogic.py`: 28 passed, 573 subtests. The dungeons, owg and inverted suites have pre-existing expectation failures (181, 3 and 20) that this PR does not change.
- Minimum chest keys per location under static, for every small key and big key placement in open, standard and inverted, compared with ER's own rules (3979 pairs per mode): all match except ER's quirks (Swamp and Skull Woods Big Chest holding their own big key; inverted Mire Main Lobby; inverted TR Big Key Chest with its key inside; standard HC sewers, where ER has no guard drops).
- 1000 crossed-entrance keysanity seeds with accessibility locations under static: no ER key forbid violated in any spoiler.
